### PR TITLE
Refactor EventCall to store Event Declaration

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -774,6 +774,11 @@ def propagate_types(ir, node: "Node"):  # pylint: disable=too-many-locals
                 raise SlithIRError("Not handling {} during type propagation".format(type(ir)))
     return None
 
+def resolve_event(event_name, event_collection):
+    for event in event_collection.events:
+        if event.name == event_name:
+            return event
+    return None
 
 def extract_tmp_call(ins: TmpCall, contract: Optional[Contract]):  # pylint: disable=too-many-locals
     assert isinstance(ins, TmpCall)
@@ -800,8 +805,9 @@ def extract_tmp_call(ins: TmpCall, contract: Optional[Contract]):  # pylint: dis
                 internalcall.set_expression(ins.expression)
                 internalcall.call_id = ins.call_id
                 return internalcall
-            if str(ins.ori.variable_right) in [f.name for f in contract.events]:
-                eventcall = EventCall(ins.ori.variable_right)
+            event_sym = resolve_event(ins.ori.variable_right, contract)
+            if event_sym is not None:
+                eventcall = EventCall(event_sym)
                 eventcall.set_expression(ins.expression)
                 eventcall.call_id = ins.call_id
                 return eventcall
@@ -817,8 +823,9 @@ def extract_tmp_call(ins: TmpCall, contract: Optional[Contract]):  # pylint: dis
             # lib L { event E()}
             # ...
             # emit L.E();
-            if str(ins.ori.variable_right) in [f.name for f in ins.ori.variable_left.events]:
-                eventcall = EventCall(ins.ori.variable_right)
+            event_sym = resolve_event(ins.ori.variable_right, ins.ori.variable_left)
+            if event_sym is not None:
+                eventcall = EventCall(event_sym)
                 eventcall.set_expression(ins.expression)
                 eventcall.call_id = ins.call_id
                 return eventcall
@@ -1008,7 +1015,7 @@ def extract_tmp_call(ins: TmpCall, contract: Optional[Contract]):  # pylint: dis
         return op
 
     if isinstance(ins.called, Event):
-        e = EventCall(ins.called.name)
+        e = EventCall(ins.called)
         e.set_expression(ins.expression)
         return e
 

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -805,7 +805,7 @@ def extract_tmp_call(ins: TmpCall, contract: Optional[Contract]):  # pylint: dis
                 internalcall.set_expression(ins.expression)
                 internalcall.call_id = ins.call_id
                 return internalcall
-            event_sym = resolve_event(ins.ori.variable_right, contract)
+            event_sym = resolve_event(str(ins.ori.variable_right), contract)
             if event_sym is not None:
                 eventcall = EventCall(event_sym)
                 eventcall.set_expression(ins.expression)
@@ -823,7 +823,7 @@ def extract_tmp_call(ins: TmpCall, contract: Optional[Contract]):  # pylint: dis
             # lib L { event E()}
             # ...
             # emit L.E();
-            event_sym = resolve_event(ins.ori.variable_right, ins.ori.variable_left)
+            event_sym = resolve_event(str(ins.ori.variable_right), ins.ori.variable_left)
             if event_sym is not None:
                 eventcall = EventCall(event_sym)
                 eventcall.set_expression(ins.expression)

--- a/slither/slithir/operations/event_call.py
+++ b/slither/slithir/operations/event_call.py
@@ -2,14 +2,18 @@ from slither.slithir.operations.call import Call
 
 
 class EventCall(Call):
-    def __init__(self, name):
+    def __init__(self, destination):
         super().__init__()
-        self._name = name
+        self._destination = destination
         # todo add instance of the Event
 
     @property
+    def destination(self):
+        return self._destination
+
+    @property
     def name(self):
-        return self._name
+        return self.destination.name
 
     @property
     def read(self):

--- a/slither/slithir/operations/event_call.py
+++ b/slither/slithir/operations/event_call.py
@@ -5,7 +5,6 @@ class EventCall(Call):
     def __init__(self, destination):
         super().__init__()
         self._destination = destination
-        # todo add instance of the Event
 
     @property
     def destination(self):

--- a/slither/slithir/utils/ssa.py
+++ b/slither/slithir/utils/ssa.py
@@ -8,6 +8,7 @@ from slither.core.declarations import (
     SolidityFunction,
     SolidityVariable,
     Structure,
+    Event,
 )
 from slither.core.declarations.solidity_import_placeholder import SolidityImportPlaceHolder
 from slither.core.solidity_types.type import Type
@@ -617,6 +618,7 @@ def get(
             Function,
             Type,
             SolidityImportPlaceHolder,
+            Event,
         ),
     )  # type for abi.decode(.., t)
     return variable
@@ -687,8 +689,8 @@ def copy_ir(ir, *instances):
         variable = get_variable(ir, lambda x: x.variable, *instances)
         return Delete(lvalue, variable)
     if isinstance(ir, EventCall):
-        name = ir.name
-        return EventCall(name)
+        destination = get_variable(ir, lambda x: x.destination, *instances)
+        return EventCall(destination)
     if isinstance(ir, HighLevelCall):  # include LibraryCall
         destination = get_variable(ir, lambda x: x.destination, *instances)
         function_name = ir.function_name


### PR DESCRIPTION
Previously an EventCall only store the name of the event (as a string), which isn't ideal for a lot of purpose. Now it stores the event object, as it should be.