### PR TITLE
Record Abstract Contract Information

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -80,7 +80,7 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
         self._using_for_src: Dict[Union[str, Type], List[Tuple[Type, "StructureContract"]]] = {}
         self._kind: Optional[str] = None
         self._is_interface: bool = False
-        self._is_abstract = False
+        self._is_abstract: bool = False
 
         self._signatures: Optional[List[str]] = None
         self._signatures_declared: Optional[List[str]] = None

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -80,6 +80,7 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
         self._using_for_src: Dict[Union[str, Type], List[Tuple[Type, "StructureContract"]]] = {}
         self._kind: Optional[str] = None
         self._is_interface: bool = False
+        self._is_abstract = False
 
         self._signatures: Optional[List[str]] = None
         self._signatures_declared: Optional[List[str]] = None
@@ -145,6 +146,14 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
     @is_interface.setter
     def is_interface(self, is_interface: bool):
         self._is_interface = is_interface
+
+    @property
+    def is_abstract(self) -> bool:
+        return self.is_abstract
+
+    @is_abstract.setter
+    def is_abstract(self, is_abstract: bool):
+        self._is_abstract = is_abstract
 
     # endregion
     ###################################################################################

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -158,6 +158,8 @@ class ContractSolc(CallerContextExpression):
             if attributes["contractKind"] == "interface":
                 self._contract.is_interface = True
             self._contract.kind = attributes["contractKind"]
+        if "abstract" in attributes:
+            self._contract._is_abstract = attributes["abstract"]
         self._linearized_base_contracts = attributes["linearizedBaseContracts"]
         # self._contract.fullyImplemented = attributes["fullyImplemented"]
 

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -159,7 +159,7 @@ class ContractSolc(CallerContextExpression):
                 self._contract.is_interface = True
             self._contract.kind = attributes["contractKind"]
         if "abstract" in attributes:
-            self._contract._is_abstract = attributes["abstract"]
+            self._contract._is_abstract = attributes["abstract"] == True
         self._linearized_base_contracts = attributes["linearizedBaseContracts"]
         # self._contract.fullyImplemented = attributes["fullyImplemented"]
 


### PR DESCRIPTION
For some reason, slither did not record whether a contract is abstract. This PR extends that feature by recording it in a field `is_abstract` in `Contract` class.