### PR TITLE
Store Custom Error Instance in LibraryCall

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -774,10 +774,16 @@ def propagate_types(ir, node: "Node"):  # pylint: disable=too-many-locals
                 raise SlithIRError(f"Not handling {type(ir)} during type propagation")
     return None
 
-def resolve_event(event_name, event_collection):
-    for event in event_collection.events:
+def resolve_event(event_name : str, c : Contract) -> Optional["Event"]:
+    for event in c.events:
         if event.name == event_name:
             return event
+    return None
+
+def resolve_error(error_name : str, c : Contract) -> Optional["CustomError"]:
+    for ce in c.custom_errors:
+        if ce.name == error_name:
+            return ce
     return None
 
 def extract_tmp_call(ins: TmpCall, contract: Optional[Contract]):  # pylint: disable=too-many-locals
@@ -837,6 +843,9 @@ def extract_tmp_call(ins: TmpCall, contract: Optional[Contract]):  # pylint: dis
                 ins.lvalue,
                 ins.type_call,
             )
+            custom_error_sym = resolve_error(str(ins.ori.variable_right), ins.ori.variable_left)
+            if custom_error_sym is not None:
+                libcall.function = custom_error_sym
             libcall.set_expression(ins.expression)
             libcall.call_id = ins.call_id
             return libcall


### PR DESCRIPTION
This is similar to #3 , a library call to a custom error only stored the name of such custom error, but not its instance. This PR extends that feature by recording the instance.