### PR TITLE
Output expressions to slither findings

### DIFF
--- a/slither/utils/output.py
+++ b/slither/utils/output.py
@@ -239,6 +239,9 @@ def _convert_to_description(d):
     if hasattr(d, "name"):
         return f"{d.name} ({d.source_mapping_str})"
 
+    if isinstance(d, Expression):
+        return f"{d}({d.source_mapping_str})"
+
     raise SlitherError(f"{type(d)} cannot be converted (no name, or canonical_name")
 
 
@@ -259,6 +262,9 @@ def _convert_to_markdown(d, markdown_root):
 
     if hasattr(d, "name"):
         return f"[{d.name}]({d.source_mapping_to_markdown(markdown_root)})"
+
+    if isinstance(d, Expression):
+        return f"{d}({d.source_mapping_to_markdown(markdown_root)})"
 
     raise SlitherError(f"{type(d)} cannot be converted (no name, or canonical_name")
 
@@ -288,6 +294,9 @@ def _convert_to_id(d):
 
     if hasattr(d, "name"):
         return f"{d.name}"
+
+    if isinstance(d, Expression):
+        return f"{d}({d.source_mapping_str})"
 
     raise SlitherError(f"{type(d)} cannot be converted (no name, or canonical_name")
 


### PR DESCRIPTION
### Notes

#### Rev1
Adding expressions to the findings list was causing the slither output json generator to crash because `Expression`s do not have name fields. This fix, suggested by Duckki, works around this by adding support for formatting `Expression`s to the slither output generator.

### Testing
* Using this branch's latest commit of Slither, copy the source of the [Metadream II](https://acc.audit.certikpowered.info/project/08ffc9d0-22a6-11ed-a527-e76fbbb27216) audit project to the source directory under the `slither-task` root. Change the `IWWEMIX` casts in `Wemix2-Test/Staking.sol` so that the values expression being casted are arbitrary numeric literals, e.g. `IWWEMIX(address(0x20)).deposit{value: amount}();`. Run `./run-in-pipenv.sh` from the `slither-task` root and observe that no json conversion error occurs in the post-processing step.
* Check that the third party dependencies have been reported in a reasonable way by running `./show-findings.sh`
* Run `./evaluate.sh run 100` and verify that the results have not changed.

### Related Issue
[SnippetGeneration function crashes](https://github.com/CertiKProject/slither-task/issues/122)