### PR TITLE
fixed some issues that were missed when merging 0.9.1. changed `kind`…

### DIFF
--- a/slither/utils/output.py
+++ b/slither/utils/output.py
@@ -410,7 +410,7 @@ class Output:
         elif isinstance(add, Node):
             self.add_node(add, additional_fields=additional_fields)
         elif isinstance(add, CustomError):
-            self.add_other(add.name, add.source_mapping, add.compilation_unit, additional_fields=additional_fields)
+            self.add_other(add.name, add.source_mapping.to_json(), add.compilation_unit, additional_fields=additional_fields)
         elif isinstance(add, Expression):
             self.add_expression(add, additional_fields=additional_fields)
         else:
@@ -460,7 +460,7 @@ class Output:
     def add_contract(self, contract: Contract, additional_fields: Optional[Dict] = None):
         if additional_fields is None:
             additional_fields = {}
-        type_specific_fields = {"kind": "abstract" if contract.is_abstract else contract.kind}
+        type_specific_fields = {"kind": "abstract" if contract.is_abstract else contract.contract_kind}
         element = _create_base_element(
             "contract", contract.name, contract.source_mapping.to_json(), type_specific_fields, additional_fields
         )
@@ -652,7 +652,7 @@ class Output:
         if additional_fields is None:
             additional_fields = {}
         element = _create_base_element(
-            "expression", str(expression), expression.source_mapping, {}, additional_fields
+            "expression", str(expression), expression.source_mapping.to_json(), {}, additional_fields
         )
         self._data["elements"].append(element)
 


### PR DESCRIPTION
### Notes

#### Rev1
This fixes some issues that were missed initially when merging in the 0.9.1 source code. We have changed all occurrences of `contract` to `contract_kind`, and also passed source mappings to output formatting code in json form.

### Testing
* Check out the `merge-0.9.1` branch of `slither-task`, run `make update` and `pipenv install`, and then replace the `utilities/slither` directory with this commit.
* Run `./evaluate.sh run 100` then `./evaluate diff`. Only the `nfa` project fails where it was previously recorded as successful. The `nfa` project has missing source code, so it shouldn't succeed.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/171