### PR TITLE
fix: record 'id' of identifiers in destructuring tuple. use for renaming l…

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -770,6 +770,7 @@ class FunctionSolc(CallerContextExpression):
                     for v in variables:
                         identifier = {
                             "nodeType": "Identifier",
+                            "id": v["id"],
                             "src": v["src"],
                             "name": v["name"],
                             "typeDescriptions": {"typeString": v["typeDescriptions"]["typeString"]},

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -770,7 +770,7 @@ class FunctionSolc(CallerContextExpression):
                     for v in variables:
                         identifier = {
                             "nodeType": "Identifier",
-                            "id": v["id"],
+                            "referencedDeclaration": v["id"],
                             "src": v["src"],
                             "name": v["name"],
                             "typeDescriptions": {"typeString": v["typeDescriptions"]["typeString"]},

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -456,6 +456,8 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
 
         if "referencedDeclaration" in expression:
             referenced_declaration = expression["referencedDeclaration"]
+        elif "id" in expression:
+            referenced_declaration = expression["id"]
         else:
             referenced_declaration = None
         var, was_created = find_variable(value, caller_context, referenced_declaration)

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -456,8 +456,6 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
 
         if "referencedDeclaration" in expression:
             referenced_declaration = expression["referencedDeclaration"]
-        elif "id" in expression:
-            referenced_declaration = expression["id"]
         else:
             referenced_declaration = None
         var, was_created = find_variable(value, caller_context, referenced_declaration)


### PR DESCRIPTION
### Notes

Consider the following code:
```
pragma solidity 0.8.13;

contract Test
{
    function f1() public view returns (string memory, int)  {
        return ("hello", 0);
    }

    function f2(bool a) public view returns (string memory)  {
        if (a) {
            (string memory q, int z) = f1();
            return q;
        } else {
            (string memory q, int z) = f1();
            return q;
        }

    }
}
```

When running slither on the above code, we get an incorrect uninitialized variable finding:
```
Test.f2(bool).q_scope_0 (source/test.sol#15) is a local variable never initialized
Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#uninitialized-local-variables
```

This happens because solidity's AST+CFG generator renames variable definitions to avoid duplicate names. In the above code, both `q` and `z` are renamed in the else branch. However, `q` is renamed only at its occurrence in the return statement and not in its declaration. This happens because the declaration id is used to look up revised names, and the AST+CFG generator does not record the declaration id of the identifier in the declaration itself. (The id is in the json ast, but it is not copied to the python AST.) 

This change copies the declaration `id` into the `referencedDeclaration` field for the declaration-site identifier. This allows us to substitute its renaming. 

### Testing
* Clone `slither-task`
* Copy the above code snippet to `./source/test.solc` under the `slither-task` root
* Clone this branch to `slither-task/utilities/slither`
* Run the above code snippet using `SOLC_VERSION=0.8.13 pipenv run slither ./source/test.solc` and verify there is no spurious uninitialized variable finding
* Diff the files in `output/commit/tmp/slither-out.json` generated with and without this branch's changes. Verify there is no difference.
* Run `./evaluate.sh run 100` and then `./evaluate.sh diff`. Verify that only difference is a single project that builds successfully now and failed previously.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/191