### PR TITLE
fix: make catch parameters visible in control flow graph

### DIFF
--- a/slither/core/declarations/solidity_variables.py
+++ b/slither/core/declarations/solidity_variables.py
@@ -80,6 +80,9 @@ SOLIDITY_FUNCTIONS: Dict[str, List[str]] = {
     "balance(address)": ["uint256"],
     "code(address)": ["bytes"],
     "codehash(address)": ["bytes32"],
+    "certik_unknown_string()": ["string"],
+    "certik_unknown_bytes()": ["bytes"],
+    "certik_unknown_uint()": ["uint"]
 }
 
 


### PR DESCRIPTION
### Notes

When we run Slither on the following file, we get various false positives:
```
pragma solidity 0.8.13;

contract Other {
    function f1() external pure returns (uint,uint) {
        return (0,7);
    }
}

contract Test {

    Other o;
    string t;

    function f2(uint zzz) external returns (uint) {

        try o.f1() returns (uint x, uint p) {
            if (x == zzz) {
            return p;
            }
        } catch Panic(uint a) {
            return a;
        } catch Error(string memory s) {
            t = s;
        } catch(bytes memory c) {
            if (c[0] == c[0]) {
                return 1;
            }
        }

        return zzz;
    }

}
```

For example, we get "variable never initialized" false positives:
```
Test.f2(uint256).c (source/test.sol#24) is a local variable never initialized
Test.f2(uint256).x (source/test.sol#16) is a local variable never initialized
Test.f2(uint256).s (source/test.sol#22) is a local variable never initialized
Test.f2(uint256).a (source/test.sol#20) is a local variable never initialized
Test.f2(uint256).p (source/test.sol#16) is a local variable never initialized
```

We also get "used before declaration" false positives:
```
Variable 'Test.f2(uint256).x (source/test.sol#16)' in Test.f2(uint256) (source/test.sol#14-31) potentially used before declaration: x == zzz (source/test.sol#17)
Variable 'Test.f2(uint256).p (source/test.sol#16)' in Test.f2(uint256) (source/test.sol#14-31) potentially used before declaration: p (source/test.sol#18)
Variable 'Test.f2(uint256).a (source/test.sol#20)' in Test.f2(uint256) (source/test.sol#14-31) potentially used before declaration: a (source/test.sol#21)
Variable 'Test.f2(uint256).s (source/test.sol#22)' in Test.f2(uint256) (source/test.sol#14-31) potentially used before declaration: t = s (source/test.sol#23)
Variable 'Test.f2(uint256).c (source/test.sol#24)' in Test.f2(uint256) (source/test.sol#14-31) potentially used before declaration: c[0] == c[0] (source/test.sol#25)
```

Both classes of false positives occur because "catch parameters", i.e. the variables bound to caught values in try/catch statements, are not declared anywhere in the CFG. 

Our solution to this is as follows:
* For *proper* catch clauses, which handle cases where the function raises an error, we insert a variable declaration nodes into the CFG for the catch parameter (if any is provided)
* For the try clause, we insert variable declarations for each parameter before try node. We also assign the declarations to the results of the called function in the try node. It would be more natural to place these declarations and assignment under the try clause in the CFG; however, I wasn't sure how to pass the names of the variables holding the called function's results to the code the function that "parses" the try clause.
* These CFG modifications are done by providing custom solc json ast into the parser. This is somewhat of a hack, but it's a technique that is already used in slither, for example in the `parse_variable_definition` function.

### Testing
* Test the example above using `pipenv run slither example.sol`. Verify that the false positives have been eliminated.
* Run `./evaluate.sh run 100` from `tool-exec` and note that slither succeeds in processing all 100 projects.
* Check out the `fix-try-catch-cfg` branch of `slither-task` and run `make test`.
* For a few different projects, compare the `output/projectName/tmp/slither-out.json` files with and without this change to verify that the results have not deteriorated.
* Try this test example to ensure that "empty" catch clauses don't cause problems,
```
pragma solidity 0.8.13;

contract Other {
    function f1() external pure returns (uint,uint) {
        return (0,7);
    }
}

contract Test {

    Other o;
    string t;

    function f2(uint zzz) external returns (uint) {

        try o.f1() returns (uint x, uint p) {
            if (x == zzz) {
            return p;
            }
        } catch Panic(uint a) {
            return a;
        } catch Error(string memory s) {
            t = s;
        catch {}

        return zzz;
    }

}

```

### Revisions

Revision 3 - catch parameters are assigned to calls to unknown value functions instead of arbitrary values. The unknown value functions are called certik_unknown_*typename* and are interpreted as built-in functions (SolidityCall).

Revision 2 - handle catch clauses without parameters, which were previously causing the new code to raise errors

### Related Issue
https://github.com/CertiKProject/slither-task/issues/188
https://github.com/CertiKProject/slither-task/issues/190

### Additional Notes

Tests for these changes have been added to the `slither-task` repo in [this PR](https://github.com/CertiKProject/slither-task/pull/205).
