### PR TITLE
handle alternative IR and CFG

### DIFF
--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -72,6 +72,7 @@ class SlitherCore(Context):
         self._show_ignored_findings = False
 
         self._compilation_units: List[SlitherCompilationUnit] = []
+        self._certik_compilation_units: List[SlitherCompilationUnit] = []
 
         self._contracts: List[Contract] = []
         self._contracts_derived: List[Contract] = []
@@ -89,6 +90,14 @@ class SlitherCore(Context):
     @property
     def compilation_units(self) -> List[SlitherCompilationUnit]:
         return list(self._compilation_units)
+
+    @property
+    def certik_compilation_units(self) -> List[SlitherCompilationUnit]:
+        """
+        The list of all compilation units generated to include the CertiK version
+        of the CFG and IR.
+        """
+        return list(self._certik_compilation_units)
 
     def add_compilation_unit(self, compilation_unit: SlitherCompilationUnit):
         self._compilation_units.append(compilation_unit)

--- a/slither/detectors/abstract_detector.py
+++ b/slither/detectors/abstract_detector.py
@@ -139,6 +139,13 @@ class AbstractDetector(metaclass=abc.ABCMeta):
         if self.logger:
             self.logger.info(self.color(info))
 
+    @property
+    def uses_certik_ir() -> bool:
+        """
+        Does this detector expect the CertiK version of SlithIR?
+        """
+        return False
+
     @abc.abstractmethod
     def _detect(self) -> List[Output]:
         """TODO Documentation"""

--- a/slither/printers/all_printers.py
+++ b/slither/printers/all_printers.py
@@ -5,6 +5,7 @@ from .inheritance.inheritance import PrinterInheritance
 from .inheritance.inheritance_graph import PrinterInheritanceGraph
 from .call.call_graph import PrinterCallGraph
 from .functions.authorization import PrinterWrittenVariablesAndAuthorization
+from .summary.certikir import PrinterCertiKIR
 from .summary.slithir import PrinterSlithIR
 from .summary.slithir_ssa import PrinterSlithIRSSA
 from .summary.human_summary import PrinterHumanSummary

--- a/slither/printers/summary/certikir.py
+++ b/slither/printers/summary/certikir.py
@@ -1,0 +1,17 @@
+"""
+    Module printing summary of the contract using CertiK IR
+"""
+from typing import List
+
+from slither.printers.summary.slithir import PrinterSlithIR
+from slither.core.compilation_unit import SlitherCompilationUnit
+
+class PrinterCertiKIR(PrinterSlithIR):
+    ARGUMENT = "certikir"
+    HELP = "Print the Certik IR representation of the functions"
+
+    WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#slithir"
+
+    @property
+    def compilation_units(self) -> List[SlitherCompilationUnit]:
+        return self.slither.certik_compilation_units

--- a/slither/printers/summary/slithir.py
+++ b/slither/printers/summary/slithir.py
@@ -3,7 +3,8 @@
 """
 from slither.core.declarations import Function
 from slither.printers.abstract_printer import AbstractPrinter
-
+from typing import List
+from slither.core.compilation_unit import SlitherCompilationUnit
 
 def _print_function(function: Function) -> str:
     txt = ""
@@ -26,6 +27,13 @@ class PrinterSlithIR(AbstractPrinter):
 
     WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#slithir"
 
+    @property
+    def compilation_units(self) -> List[SlitherCompilationUnit]:
+        """
+        List of compilation units to print the IR for
+        """
+        return self.slither.compilation_units
+
     def output(self, _filename):
         """
         _filename is not used
@@ -34,7 +42,7 @@ class PrinterSlithIR(AbstractPrinter):
         """
 
         txt = ""
-        for compilation_unit in self.slither.compilation_units:
+        for compilation_unit in self.compilation_units:
             for contract in compilation_unit.contracts:
                 if contract.is_top_level:
                     continue

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -1,4 +1,5 @@
 import logging
+
 from typing import Union, List, ValuesView, Type, Dict
 
 from crytic_compile import CryticCompile, InvalidCompilation
@@ -93,16 +94,25 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         except InvalidCompilation as e:
             # pylint: disable=raise-missing-from
             raise SlitherError(f"Invalid compilation: \n{str(e)}")
+
         for compilation_unit in crytic_compile.compilation_units.values():
             compilation_unit_slither = SlitherCompilationUnit(self, compilation_unit)
             self._compilation_units.append(compilation_unit_slither)
-            parser = SlitherCompilationUnitSolc(compilation_unit_slither)
+            parser = SlitherCompilationUnitSolc(compilation_unit_slither, False)
             self._parsers.append(parser)
+
+            new_compilation_unit_slither = SlitherCompilationUnit(self, compilation_unit)
+            self._certik_compilation_units.append(new_compilation_unit_slither)
+            new_parser = SlitherCompilationUnitSolc(new_compilation_unit_slither, True)
+            self._parsers.append(new_parser)
+
             for path, ast in compilation_unit.asts.items():
                 parser.parse_top_level_from_loaded_json(ast, path)
+                new_parser.parse_top_level_from_loaded_json(ast, path)
                 self.add_source_code(path)
 
             _update_file_scopes(compilation_unit_slither.scopes.values())
+            _update_file_scopes(new_compilation_unit_slither.scopes.values())
 
         if kwargs.get("generate_patches", False):
             self.generate_patches = True
@@ -186,9 +196,16 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         """
         _check_common_things("detector", detector_class, AbstractDetector, self._detectors)
 
-        for compilation_unit in self.compilation_units:
-            instance = detector_class(compilation_unit, self, logger_detector)
-            self._detectors.append(instance)
+        if detector_class.uses_certik_ir:
+            for compilation_unit in self.certik_compilation_units:
+                instance = detector_class(compilation_unit, self, logger_detector)
+                self._detectors.append(instance)
+        else:
+            for compilation_unit in self.compilation_units:
+                instance = detector_class(compilation_unit, self, logger_detector)
+                self._detectors.append(instance)
+
+
 
     def register_printer(self, printer_class: Type[AbstractPrinter]) -> None:
         """

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -98,12 +98,12 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         for compilation_unit in crytic_compile.compilation_units.values():
             compilation_unit_slither = SlitherCompilationUnit(self, compilation_unit)
             self._compilation_units.append(compilation_unit_slither)
-            parser = SlitherCompilationUnitSolc(compilation_unit_slither, False)
+            parser = SlitherCompilationUnitSolc(compilation_unit_slither, generates_certik_ir = False)
             self._parsers.append(parser)
 
             new_compilation_unit_slither = SlitherCompilationUnit(self, compilation_unit)
             self._certik_compilation_units.append(new_compilation_unit_slither)
-            new_parser = SlitherCompilationUnitSolc(new_compilation_unit_slither, True)
+            new_parser = SlitherCompilationUnitSolc(new_compilation_unit_slither, generates_certik_ir = True)
             self._parsers.append(new_parser)
 
             for path, ast in compilation_unit.asts.items():

--- a/slither/solc_parsing/slither_compilation_unit_solc.py
+++ b/slither/solc_parsing/slither_compilation_unit_solc.py
@@ -59,12 +59,13 @@ def _handle_import_aliases(
 
 class SlitherCompilationUnitSolc:
     # pylint: disable=no-self-use,too-many-instance-attributes
-    def __init__(self, compilation_unit: SlitherCompilationUnit):
+    def __init__(self, compilation_unit: SlitherCompilationUnit, generates_certik_ir: bool):
         super().__init__()
 
         self._contracts_by_id: Dict[int, ContractSolc] = {}
         self._parsed = False
         self._analyzed = False
+        self._generates_certik_ir = generates_certik_ir
 
         self._underlying_contract_to_parser: Dict[Contract, ContractSolc] = {}
         self._structures_top_level_parser: List[StructureTopLevelSolc] = []
@@ -83,6 +84,13 @@ class SlitherCompilationUnitSolc:
     @property
     def compilation_unit(self) -> SlitherCompilationUnit:
         return self._compilation_unit
+
+    @property
+    def generates_certik_ir(self) -> bool:
+        """
+        Does this parser generate the CertiK version of SlithIR?
+        """
+        return self._generates_certik_ir
 
     @property
     def all_functions_and_modifiers_parser(self) -> List[FunctionSolc]:


### PR DESCRIPTION
### Notes

To begin using a new IR format without breaking existing detectors, we will set a flag `generates_certik_ir` in the top-level IR/CFG generator `SlitherCompilationUnitSolc`. For each file, we will create two IR generators, one for the certik IR variant and the other for the existing SlithIR format. Existing detectors will use the old IR format. To cause a new detector to use the new format, we will override the `uses_certik_ir` property of `AbstractDetector` to return `True`.

A new printer called `certikir` has been added. This is similar to `slithir` but prints CertiK IR variant instead of SlithIR.

### Testing
* Run `./evaluate.sh run 100` and verify that all projects succeed
* Replace `variable_declaration.py` with the below code (which adds default value initialization to uninitialized variable declaration statements) and run the `certikir` printer. Note that unlike `slithir`, `certikir` generates some instructions for default value initialization.

`variable_declaration.py`
```
import logging
import re
import copy
from typing import Dict, Optional, TYPE_CHECKING

from slither.solc_parsing.declarations.caller_context import CallerContextExpression
from slither.solc_parsing.expressions.expression_parsing import parse_expression

from slither.core.expressions.expression import Expression
from slither.core.variables.variable import Variable
from slither.core.solidity_types import Type, UserDefinedType, ArrayType
from slither.solc_parsing.solidity_types.type_parsing import parse_type, UnknownType

from slither.core.solidity_types.elementary_type import (
    ElementaryType,
    NonElementaryType,
)
from slither.solc_parsing.exceptions import ParsingError

from slither.core.expressions.literal import Literal
from slither.core.expressions import (
    MemberAccess, Identifier, CallExpression,
    NewArray, TupleExpression, TypeConversion
)
from slither.core.solidity_types.elementary_type import Byte, Int, Uint

from slither.core.declarations import Enum
from slither.core.declarations.structure import Structure
from slither.core.declarations.contract import Contract
from slither.core.declarations.solidity_variables import SolidityFunction

if TYPE_CHECKING:
    from slither.solc_parsing.declarations.function import FunctionSolc

logger = logging.getLogger("VariableDeclarationSolcParsing")


class MultipleVariablesDeclaration(Exception):
    """
    This is raised on
    var (a,b) = ...
    It should occur only on local variable definition
    """

    # pylint: disable=unnecessary-pass
    pass


class VariableDeclarationSolc:
    def __init__(
        self, variable: Variable, variable_data: Dict
    ):  # pylint: disable=too-many-branches
        """
        A variable can be declared through a statement, or directly.
        If it is through a statement, the following children may contain
        the init value.
        It may be possible that the variable is declared through a statement,
        but the init value is declared at the VariableDeclaration children level
        """

        self._variable = variable
        self._was_analyzed = False
        self._elem_to_parse = None
        self._initializedNotParsed = None

        self._is_compact_ast = False
        self._from_statement = False
        self._reference_id = None

        if "nodeType" in variable_data:
            self._is_compact_ast = True
            nodeType = variable_data["nodeType"]
            if nodeType in [
                "VariableDeclarationStatement",
                "VariableDefinitionStatement",
            ]:
                self._from_statement = True
                if len(variable_data["declarations"]) > 1:
                    raise MultipleVariablesDeclaration
                init = None
                if "initialValue" in variable_data:
                    init = variable_data["initialValue"]

                self._init_from_declaration(variable_data["declarations"][0], init)
            elif nodeType == "VariableDeclaration":
                self._from_statement = False
                self._init_from_declaration(variable_data, variable_data.get("value", None))
            else:
                raise ParsingError(f"Incorrect variable declaration type {nodeType}")

        else:
            nodeType = variable_data["name"]

            if nodeType in [
                "VariableDeclarationStatement",
                "VariableDefinitionStatement",
            ]:
                self._from_statement = True
                if len(variable_data["children"]) == 2:
                    init = variable_data["children"][1]
                elif len(variable_data["children"]) == 1:
                    init = None
                elif len(variable_data["children"]) > 2:
                    raise MultipleVariablesDeclaration
                else:
                    raise ParsingError(
                        "Variable declaration without children?" + str(variable_data)
                    )
                declaration = variable_data["children"][0]
                self._init_from_declaration(declaration, init)
            elif nodeType == "VariableDeclaration":
                self._from_statement = False
                self._init_from_declaration(variable_data, False)
            else:
                raise ParsingError(f"Incorrect variable declaration type {nodeType}")

    @property
    def underlying_variable(self) -> Variable:
        return self._variable

    @property
    def reference_id(self) -> int:
        """
        Return the solc id. It can be compared with the referencedDeclaration attr
        Returns None if it was not parsed (legacy AST)
        """
        return self._reference_id

    def _handle_comment(self, attributes: Dict):
        if "documentation" in attributes and "text" in attributes["documentation"]:

            candidates = attributes["documentation"]["text"].split(",")

            for candidate in candidates:
                if "@custom:security non-reentrant" in candidate:
                    self._variable.is_reentrant = False

                write_protection = re.search(
                    r'@custom:security write-protection="([\w, ()]*)"', candidate
                )
                if write_protection:
                    if self._variable.write_protection is None:
                        self._variable.write_protection = []
                    self._variable.write_protection.append(write_protection.group(1))

    def _analyze_variable_attributes(self, attributes: Dict):
        if "visibility" in attributes:
            self._variable.visibility = attributes["visibility"]
        else:
            self._variable.visibility = "internal"

    def _init_from_declaration(self, var: Dict, init: Optional[Dict]):  # pylint: disable=too-many-branches
        if self._is_compact_ast:
            attributes = var
            self._typeName = attributes["typeDescriptions"]["typeString"]
        else:
            assert len(var["children"]) <= 2
            assert var["name"] == "VariableDeclaration"

            attributes = var["attributes"]
            self._typeName = attributes["type"]

        self._variable.name = attributes["name"]
        # self._arrayDepth = 0
        # self._isMapping = False
        # self._mappingFrom = None
        # self._mappingTo = False
        # self._initial_expression = None
        # self._type = None

        # Only for comapct ast format
        # the id can be used later if referencedDeclaration
        # is provided
        if "id" in var:
            self._reference_id = var["id"]

        if "constant" in attributes:
            self._variable.is_constant = attributes["constant"]

        if "mutability" in attributes:
            # Note: this checked is not needed if "constant" was already in attribute, but we keep it
            # for completion
            if attributes["mutability"] == "constant":
                self._variable.is_constant = True
            if attributes["mutability"] == "immutable":
                self._variable.is_immutable = True

        self._handle_comment(attributes)

        self._analyze_variable_attributes(attributes)

        if self._is_compact_ast:
            if var["typeName"]:
                self._elem_to_parse = var["typeName"]
            else:
                self._elem_to_parse = UnknownType(var["typeDescriptions"]["typeString"])
        else:
            if not var["children"]:
                # It happens on variable declared inside loop declaration
                try:
                    self._variable.type = ElementaryType(self._typeName)
                    self._elem_to_parse = None
                except NonElementaryType:
                    self._elem_to_parse = UnknownType(self._typeName)
            else:
                self._elem_to_parse = var["children"][0]

        if self._is_compact_ast:
            self._initializedNotParsed = init
            if init:
                self._variable.initialized = True
        else:
            if init:  # there are two way to init a var local in the AST
                assert len(var["children"]) <= 1
                self._variable.initialized = True
                self._initializedNotParsed = init
            elif len(var["children"]) in [0, 1]:
                self._variable.initialized = False
                self._initializedNotParsed = []
            else:
                assert len(var["children"]) == 2
                self._variable.initialized = True
                self._initializedNotParsed = var["children"][1]

    def _get_init_value(self, ty : Type) -> Expression:

        if isinstance(ty, ElementaryType) and (ty.type in Int + Uint + Byte + ["address"]):
            return Literal("0", ElementaryType(ty.type))
        elif isinstance(ty, ElementaryType) and (ty.type == "string"):
            return Literal("", ElementaryType("string"))
        elif isinstance(ty, ElementaryType) and (ty.type == "bool"):
            return Literal("false", ElementaryType("bool"))
        elif isinstance(ty, ArrayType) and ty.is_dynamic_array:
            return CallExpression(
                NewArray(1, copy.deepcopy(ty.type)),
                [Literal("0", ElementaryType("uint256"))],
                f"{ty.type}[] memory"
            )
        elif isinstance(ty, ArrayType) and ty.is_fixed_array:
            length = int(ty.length_value.value)
            base_init_value = self._get_init_value(ty.type)
            return TupleExpression([copy.deepcopy(base_init_value) for _ in range(0, length)])
        elif isinstance(ty, UserDefinedType) and isinstance(ty.type, Enum):
            return MemberAccess(
                "min",
                ty,
                CallExpression(
                    Identifier(SolidityFunction("type()")),
                    [Identifier(ty.type)],
                    f"type(enum {ty.type.name})"
                )
            )
        elif isinstance(ty, UserDefinedType) and isinstance(ty.type, Structure):
            return CallExpression(
                Identifier(copy.deepcopy(ty.type)),
                [self._get_init_value(field.type) for field in ty.type.elems_ordered],
                f"struct {ty.type.name} memory"
            )
        elif isinstance(ty, UserDefinedType) and isinstance(ty.type, Contract):
            return TypeConversion(
                TypeConversion(Literal("0", ElementaryType("uint256")), ElementaryType("address")),
                UserDefinedType(ty.type)
            )
        assert False # unreachable

    def analyze(self, caller_context: CallerContextExpression):
        # Can be re-analyzed due to inheritance
        if self._was_analyzed:
            return
        self._was_analyzed = True

        type_name = self._elem_to_parse

        if self._elem_to_parse:
            self._variable.type = parse_type(self._elem_to_parse, caller_context)
            self._elem_to_parse = None

        if self._variable.initialized:
            self._variable.expression = parse_expression(self._initializedNotParsed, caller_context)
            self._initializedNotParsed = None
        elif self._from_statement and caller_context.slither_parser.generates_certik_ir:
            self._variable.expression = self._get_init_value(self._variable.type)

``` 

example.sol
```
pragma solidity ^0.8.13;

struct A {
    int x;
}

contract Test {
    function store() public {
        A memory z;
    }
}
```

### Related Issue
https://github.com/CertiKProject/slither-task/issues/217
