### PR TITLE
handle 'null' try clause parameters, which can arise in older solc ve…

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -667,7 +667,7 @@ class FunctionSolc(CallerContextExpression):
         try_clause = statement["clauses"][0]
         catch_clauses = statement["clauses"][1:]
         try_params = try_clause["parameters"]["parameters"] \
-                     if "parameters" in try_clause \
+                     if ("parameters" in try_clause) and (try_clause["parameters"] != None) \
                      else []
         new_node = node
         if len(try_params) > 0:


### PR DESCRIPTION
### Notes

In older versions of solc, the generated json ast contains the value `null` to convey lack of return variables for a try clause. This is translated to `None` in python. In my recent changes to try/catch IR, I neglected to handle this.

### Testing

Try running Slither on the following file with an without these changes:
```
pragma solidity ^0.6.2;

contract Test {
    function bar() external {}
}

contract Baz {
    function foo(Test a) external {
        try a.bar() {} catch {}
    }
}
```

Without the changes, an exception is raised. With the changes, Slither runs without errors.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/220