### PR TITLE
added implicit returns

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -1178,6 +1178,8 @@ class FunctionSolc(CallerContextExpression):
 
         if self.slither_parser.generates_certik_ir:
             for ret in self._function.returns:
+                if not (ret.location in ["memory", "default"]):
+                    continue
                 new_node = self._new_node(NodeType.EXPRESSION, cfg["src"], self._function)
                 new_node.underlying_node.add_expression(
                     AssignmentOperation(

--- a/slither/solc_parsing/default_values.py
+++ b/slither/solc_parsing/default_values.py
@@ -1,0 +1,61 @@
+import copy
+from slither.core.expressions.literal import Literal
+from slither.core.solidity_types.type import Type
+from slither.core.declarations.contract import Contract
+from slither.core.declarations.solidity_variables import SolidityFunction
+from slither.core.declarations.structure import Structure
+from slither.core.declarations.enum import Enum
+from slither.core.expressions.call_expression import CallExpression
+from slither.core.expressions.expression import Expression
+from slither.core.expressions.identifier import Identifier
+from slither.core.expressions.member_access import MemberAccess
+from slither.core.expressions.new_array import NewArray
+from slither.core.expressions.tuple_expression import TupleExpression
+from slither.core.expressions.type_conversion import TypeConversion
+from slither.core.solidity_types.array_type import ArrayType
+from slither.core.solidity_types.elementary_type import Byte, ElementaryType, Int, Uint
+from slither.core.solidity_types.user_defined_type import UserDefinedType
+
+def get_default_value(ty : Type) -> Expression:
+    """
+    When a Solidity variable declaration does not have an initializer expression,
+    we use the expression returned by this function as a default initializer.
+    """
+    if isinstance(ty, ElementaryType) and (ty.type in Int + Uint + Byte + ["address"]):
+        return Literal("0", ElementaryType(ty.type))
+    elif isinstance(ty, ElementaryType) and (ty.type == "string"):
+        return Literal("", ElementaryType("string"))
+    elif isinstance(ty, ElementaryType) and (ty.type == "bool"):
+        return Literal("false", ElementaryType("bool"))
+    elif isinstance(ty, ArrayType) and ty.is_dynamic_array:
+        return CallExpression(
+            NewArray(1, copy.deepcopy(ty.type)),
+            [Literal("0", ElementaryType("uint256"))],
+            f"{ty.type}[] memory"
+        )
+    elif isinstance(ty, ArrayType) and ty.is_fixed_array:
+        length = int(ty.length_value.value)
+        base_init_value = get_default_value(ty.type)
+        return TupleExpression([copy.deepcopy(base_init_value) for _ in range(0, length)])
+    elif isinstance(ty, UserDefinedType) and isinstance(ty.type, Enum):
+        return MemberAccess(
+            "min",
+            ty,
+            CallExpression(
+                Identifier(SolidityFunction("type()")),
+                [Identifier(ty.type)],
+                f"type(enum {ty.type.name})"
+            )
+        )
+    elif isinstance(ty, UserDefinedType) and isinstance(ty.type, Structure):
+        return CallExpression(
+            Identifier(copy.deepcopy(ty.type)),
+            [get_default_value(field.type) for field in ty.type.elems_ordered],
+            f"struct {ty.type.name} memory"
+        )
+    elif isinstance(ty, UserDefinedType) and isinstance(ty.type, Contract):
+        return TypeConversion(
+            TypeConversion(Literal("0", ElementaryType("uint256")), ElementaryType("address")),
+            UserDefinedType(ty.type)
+        )
+    assert False # unreachable

--- a/slither/solc_parsing/default_values.py
+++ b/slither/solc_parsing/default_values.py
@@ -1,4 +1,3 @@
-import copy
 from slither.core.expressions.literal import Literal
 from slither.core.solidity_types.type import Type
 from slither.core.declarations.contract import Contract
@@ -29,14 +28,13 @@ def get_default_value(ty : Type) -> Expression:
         return Literal("false", ElementaryType("bool"))
     elif isinstance(ty, ArrayType) and ty.is_dynamic_array:
         return CallExpression(
-            NewArray(1, copy.deepcopy(ty.type)),
+            NewArray(1, ty.type),
             [Literal("0", ElementaryType("uint256"))],
             f"{ty.type}[] memory"
         )
     elif isinstance(ty, ArrayType) and ty.is_fixed_array:
         length = int(ty.length_value.value)
-        base_init_value = get_default_value(ty.type)
-        return TupleExpression([copy.deepcopy(base_init_value) for _ in range(0, length)])
+        return TupleExpression([get_default_value(ty.type) for _ in range(0, length)])
     elif isinstance(ty, UserDefinedType) and isinstance(ty.type, Enum):
         return MemberAccess(
             "min",
@@ -49,7 +47,7 @@ def get_default_value(ty : Type) -> Expression:
         )
     elif isinstance(ty, UserDefinedType) and isinstance(ty.type, Structure):
         return CallExpression(
-            Identifier(copy.deepcopy(ty.type)),
+            Identifier(ty.type),
             [get_default_value(field.type) for field in ty.type.elems_ordered],
             f"struct {ty.type.name} memory"
         )


### PR DESCRIPTION
### Notes

This change assigns default values to return variables at the top of each function. If the storage location is `calldata` then no assignment is performed because solc forces the programmer to assign calldata return variables before they are used. 

### Testing
Here is a test file to try
```
pragma solidity ^0.8.13;

struct A {
    int hello;
}

contract Test {
    function testFunc(A[5] calldata x) external returns (A[3] memory, A[2] memory, A[5] calldata z) {
        A[3] memory zzz;
        z = x;
    }
}
```
Print out its IR by running `SOLC_VERSION=0.8.13 pipenv run slither testfile.sol --print certikir`.

Also, run `./evaluate run 100` in tools-exec and ensure that all projects succeed.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/201