### PR TITLE
fix: changed "uses certik ir" flag to a static method

### DIFF
--- a/slither/detectors/abstract_detector.py
+++ b/slither/detectors/abstract_detector.py
@@ -162,7 +162,7 @@ class AbstractDetector(metaclass=abc.ABCMeta):
         if self.logger:
             self.logger.info(self.color(info))
 
-    @property
+    @staticmethod
     def uses_certik_ir() -> bool:
         """
         Does this detector expect the CertiK version of SlithIR?

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -192,7 +192,7 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         """
         _check_common_things("detector", detector_class, AbstractDetector, self._detectors)
 
-        if detector_class.uses_certik_ir:
+        if detector_class.uses_certik_ir():
             for compilation_unit in self.certik_compilation_units:
                 instance = detector_class(compilation_unit, self, logger_detector)
                 self._detectors.append(instance)


### PR DESCRIPTION
### Notes

Previously, all detectors were incorrectly receiving certik ir because the `uses_certik_ir` property was being read from the detector class as a "truthy" function. This PR fixes the issue by changing `uses_certik_ir` to a static method.

### Testing
* With these changes loaded to the `slither` subrepo, run 'make test' in `slither-task` root directory and verify that all tests succeed 
* Run `./evaluate run 100` from `tool-exec` and verify that all projects succeed

### Related Issue
https://github.com/CertiKProject/slither-task/issues/247