### PR TITLE
fix: if-statement CFG construction

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -362,7 +362,7 @@ class FunctionSolc(CallerContextExpression):
 
     def _parse_if(self, if_statement: Dict, node: NodeSolc) -> NodeSolc:
         # IfStatement = 'if' '(' Expression ')' Statement ( 'else' Statement )?
-        falseStatement = None
+        false_body = None
 
         if self.is_compact_ast:
             condition = if_statement["condition"]
@@ -379,13 +379,9 @@ class FunctionSolc(CallerContextExpression):
             trueStatement = self._parse_statement(
                 if_statement["trueBody"], condition_node, true_scope
             )
+
             if "falseBody" in if_statement and if_statement["falseBody"]:
-                false_scope = Scope(
-                    node.underlying_node.scope.is_checked, False, node.underlying_node.scope
-                )
-                falseStatement = self._parse_statement(
-                    if_statement["falseBody"], condition_node, false_scope
-                )
+                false_body = if_statement["falseBody"]
         else:
             children = if_statement[self.get_children("children")]
             condition = children[0]
@@ -400,19 +396,22 @@ class FunctionSolc(CallerContextExpression):
                 node.underlying_node.scope.is_checked, False, node.underlying_node.scope
             )
             trueStatement = self._parse_statement(children[1], condition_node, true_scope)
+
             if len(children) == 3:
-                false_scope = Scope(
-                    node.underlying_node.scope.is_checked, False, node.underlying_node.scope
-                )
-                falseStatement = self._parse_statement(children[2], condition_node, false_scope)
+                false_body = children[2]
 
         endIf_node = self._new_node(NodeType.ENDIF, if_statement["src"], node.underlying_node.scope)
         link_underlying_nodes(trueStatement, endIf_node)
 
-        if falseStatement:
+        if false_body:
+            false_scope = Scope(
+                node.underlying_node.scope.is_checked, False, node.underlying_node.scope
+            )
+            falseStatement = self._parse_statement(false_body, condition_node, false_scope)
             link_underlying_nodes(falseStatement, endIf_node)
         else:
             link_underlying_nodes(condition_node, endIf_node)
+
         return endIf_node
 
     def _parse_while(self, whilte_statement: Dict, node: NodeSolc) -> NodeSolc:


### PR DESCRIPTION
### Notes

When constructing if-statement cfgs, the true- and false-branch nodes were constructed and connected to the condition node before connecting anything to the end-if node. The issue with this is that when the true-branch is an empty block, the true-branch node is set to still be the condition node. Thus, when the false-branch node was constructed and connected, it became the first child of the condition node, leading it to be interpreted as being the true-branch.

To fix this, the connection from the true-branch node to the end-if node now happens before constructing and connecting the false-branch node. Now, in the case of an empty block true-branch, the condition node is connected to the end-if node first.

### Testing
* Run the slither cfg printer with the following test file:
    ```solidity
  pragma solidity ^0.8.0;
  
  contract IfElseBug {
        function test_used_in_one_path_buggy(uint a, uint b) public view returns(uint) {
          uint v = a + b;
          uint w;
  
          // empty true-branch; previously buggy
          if( a > b ) {}
          else {
              w = v;
          }
         // both branches empty
          if (a > b) {}
          else {}
          // empty false-branch
          if (a <= b) {
              w = v;
          }
          else {}
          // no false-branch
          if (v <= w) {
              w = v;
          }
          // both branches nonempty
          if (a == b) {
              v = w;
          } else {
              v = 2 * w;
          }
          return w;
      }
  }
    ```
* Ensure the cfg generated is correct for each type of if-statement.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/241