### PR TITLE
fix: unnamed variable collision from catch-bound variables

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -800,7 +800,7 @@ class FunctionSolc(CallerContextExpression):
 
         params = params["parameters"] if params and "parameters" in params else None
 
-        if (not is_try_clause) and params:
+        if (not is_try_clause) and params and (params[0]["name"] != ""):
             assert (len(params) == 1)
             parameter = params[0]
             assert parameter[self.get_key()] == "VariableDeclaration"


### PR DESCRIPTION
### Notes

**Background**

We add IR to initialize each catch-bound variable to a call to a function such as `certik_unknown_string`, `certik_unknown_bytes`, etc.
```
catch Error(string memory a) {
}
```
That way when the variable `a` is used, we do not generate a "potential use of uninitialized variable" finding.

**Problem**
If the catch-bound variable is unnamed and an unnamed variable is already in scope, the variables are not disambiguated, which causes crashes in SSA generation. For example, this file crashes slither: 
```
pragma solidity ^0.8.13;

contract A {

    function foo(uint256 tokenId) external view returns (address) {
        return address(0);
    }

    function test(address to) external view returns(address[] memory) {
        try this.foo(2) returns (address tokenOwner) {
        } catch Error(string memory /*reason*/) {
        }
        return new address[](0);
    }
}
```

**Solution**
As Duckki suggested, unnamed variables can't actually be used. We don't need to generate an initializer for them because we are not in danger of generating an uninitialized variable finding. Therefore, this PR adds a condition that refrains from generating initialization code for unnamed catch-bound variables; that way, the unnamed catch-bound variables will not occur at all in the IR.

### Testing

* Run `./evaluate.sh run 100` in `tool-exec` and verify that all projects succeed
* Run `make test`

Known projects exhibiting the issue:
4acdb71738f5b9e186a748c0aa66e5395702cc36
7a12ae3a3896c1ce526f7f1684c088afdc03b5fd

### Related Issue
https://github.com/CertiKProject/slither-task/issues/256
