### PR TITLE
fix: have inline fixed-length array arguments generate the appropriate SlithIR

### DIFF
--- a/slither/core/expressions/tuple_expression.py
+++ b/slither/core/expressions/tuple_expression.py
@@ -4,15 +4,21 @@ from slither.core.expressions.expression import Expression
 
 
 class TupleExpression(Expression):
-    def __init__(self, expressions: List[Expression]) -> None:
+    def __init__(self, expressions: List[Expression], is_inline_array: bool = False) -> None:
         assert all(isinstance(x, Expression) for x in expressions if x)
         super().__init__()
         self._expressions = expressions
+        self._is_inline_array = is_inline_array
 
     @property
     def expressions(self) -> List[Expression]:
         return self._expressions
 
+    @property
+    def is_inline_array(self) -> bool:
+        return self._is_inline_array
+
     def __str__(self) -> str:
         expressions_str = [str(e) for e in self.expressions]
-        return "(" + ",".join(expressions_str) + ")"
+        l_bracket, r_bracket = ("[","]") if self._is_inline_array else ("(",")")
+        return l_bracket + ",".join(expressions_str) + r_bracket

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -340,7 +340,7 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
                     for idx, _ in enumerate(elems):
                         if elems[idx] == "":
                             expressions.insert(idx, None)
-        t = TupleExpression(expressions)
+        t = TupleExpression(expressions, is_inline_array=expression.get("isInlineArray", False))
         t.set_offset(src, caller_context.compilation_unit)
         return t
 

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -510,7 +510,13 @@ class ExpressionToSlithIR(ExpressionVisitor):
 
     def _post_tuple_expression(self, expression):
         expressions = [get(e) if e else None for e in expression.expressions]
-        if len(expressions) == 1:
+        if expression.is_inline_array:
+            temp_var = TemporaryVariable(self._node)
+            init_arr = InitArray(expressions, temp_var)
+            self._result.append(init_arr)
+            # Use the new temporary variable in place of the array.
+            val = temp_var
+        elif len(expressions) == 1:
             val = expressions[0]
         else:
             val = expressions


### PR DESCRIPTION
### Notes

#### Rev1

When generating SlithIR for function calls with inline fixed-length array arguments, those arguments would be left as (python) lists instead of Variable objects. We would expect instead that a `InitArray` operation would be generated that initializes a temporary variable to that array, then have that temporary variable be the argument for the call.

A core issue was that these inline fixed-length array arguments were equivalent to tuples in slither. The solc AST also characterizes them as tuples, but includes an extra field `isInlineArray` that distinguishes the two. slither `TupleExpression`s did not keep this information, so they could not be handled accordingly during SlithIR generation.

This PR adds the `isInlineArray` information to the `TupleExpression` class and uses it to properly generate the described "correct" SlithIR when an inline fixed-length array is a call argument.

### Testing
Run slither's `slithir` printer on the following code:
```solidity
pragma solidity ^0.8.13;

contract Test {
    function take_arr(uint8[3] memory arr) internal returns (uint8[3] memory) {
        return [4,5,6];
    }
    function give_arr() external {
        take_arr([1, 2, 3]);
    }

    function take_bool_arr(bool[2] memory arr) internal {}
    function give_bool_arr() external {
        take_bool_arr([true, false]);
    }

    function take_not_arr(uint x, uint y) internal {}
    function give_not_arr() external {
        uint x = 1;
        take_not_arr(x, 2);
    }
}
```
Ensure that the expected SlithIR is generated. That is, the SlithIR of the calls to `take_arr` and `take_bool_arr` now have temporary variable arguments that were initialized to the arrays given, and that the call to `take_not_arr` is still correct. Note as well that the expressions are also printed properly, using square brackets instead of parens for the array arguments. 

### Related Issue
https://github.com/CertiKProject/slither-task/issues/212