### PR TITLE
rename unnamed parameters and return variables

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -1,4 +1,5 @@
 import logging
+import pdb
 from typing import Dict, Literal, Optional, Union, List, TYPE_CHECKING
 
 from slither.core.expressions.tuple_expression import TupleExpression
@@ -1332,13 +1333,13 @@ class FunctionSolc(CallerContextExpression):
         else:
             params = params[self.get_children("children")]
 
-        next_unnamed_param_id = 0
+        param_number = 0
         for param in params:
             assert param[self.get_key()] == "VariableDeclaration"
             local_var = self._add_param(param)
             if self.slither_parser.generates_certik_ir and local_var.underlying_variable.name == "":
-                local_var.underlying_variable.name = f"ANON_IN_{next_unnamed_param_id}"
-                next_unnamed_param_id += 1
+                local_var.underlying_variable.name = f"IN_{param_number}"
+            param_number += 1
             self._function.add_parameters(local_var.underlying_variable)
 
     def _parse_returns(self, returns: Dict):
@@ -1352,13 +1353,13 @@ class FunctionSolc(CallerContextExpression):
         else:
             returns = returns[self.get_children("children")]
 
-        next_unnamed_ret_id = 0
+        ret_param_number = 0
         for ret in returns:
             assert ret[self.get_key()] == "VariableDeclaration"
             local_var = self._add_param(ret)
             if self.slither_parser.generates_certik_ir and local_var.underlying_variable.name == "":
-                local_var.underlying_variable.name = f"ANON_OUT_{next_unnamed_ret_id}"
-                next_unnamed_ret_id += 1
+                local_var.underlying_variable.name = f"OUT_{ret_param_number}"
+            ret_param_number += 1
             self._function.add_return(local_var.underlying_variable)
 
     def _parse_modifier(self, modifier: Dict):

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -1332,9 +1332,13 @@ class FunctionSolc(CallerContextExpression):
         else:
             params = params[self.get_children("children")]
 
+        next_unnamed_param_id = 0
         for param in params:
             assert param[self.get_key()] == "VariableDeclaration"
             local_var = self._add_param(param)
+            if self.slither_parser.generates_certik_ir and local_var.underlying_variable.name == "":
+                local_var.underlying_variable.name = f"ANON_IN_{next_unnamed_param_id}"
+                next_unnamed_param_id += 1
             self._function.add_parameters(local_var.underlying_variable)
 
     def _parse_returns(self, returns: Dict):
@@ -1348,9 +1352,13 @@ class FunctionSolc(CallerContextExpression):
         else:
             returns = returns[self.get_children("children")]
 
+        next_unnamed_ret_id = 0
         for ret in returns:
             assert ret[self.get_key()] == "VariableDeclaration"
             local_var = self._add_param(ret)
+            if self.slither_parser.generates_certik_ir and local_var.underlying_variable.name == "":
+                local_var.underlying_variable.name = f"ANON_OUT_{next_unnamed_ret_id}"
+                next_unnamed_ret_id += 1
             self._function.add_return(local_var.underlying_variable)
 
     def _parse_modifier(self, modifier: Dict):


### PR DESCRIPTION
### Notes

Unnamed parameter and return variables pose a problem for our data flow state notation. They show up as an points-to missing its left side.
```
 ---> <const 0>
```

To solve this issue, we rename unnamed parameters to `IN_n` where `n` is the parameter number. Likewise, we rename unnamed return variables to `OUT_n`.  

### Testing
* Run `make test` and verify that tests succeed
* Run `./evaluate.sh run 100` in `tool-eval` and verify that projects succeed

Try running `slither test.sol --print certikir` where `test.sol` has the following contents:
```
pragma solidity ^0.8.13;

contract A
{
    function testFunc() external returns (uint, int a, uint) {

    }

}
```

The IR should assign variables named `OUT_0` and `OUT_2` to the constant 0.

*Revision 2*

For `returns (uint, int a, uint)` the variables are named `OUT_0` and `OUT_2` instead of `ANON_OUT_0` and `ANON_OUT_1`.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/294