### PR TITLE
fix: set source offsets for default initializerz

### DIFF
--- a/slither/solc_parsing/variables/variable_declaration.py
+++ b/slither/solc_parsing/variables/variable_declaration.py
@@ -157,6 +157,7 @@ class VariableDeclarationSolc:
             attributes = var["attributes"]
             self._typeName = attributes["type"]
 
+        self._src = attributes["src"]
         self._variable.name = attributes["name"]
         # self._arrayDepth = 0
         # self._isMapping = False
@@ -239,3 +240,5 @@ class VariableDeclarationSolc:
             and not isinstance(self._variable.type, FunctionType)
         ):
             self._variable.expression = get_default_value(self._variable.type)
+            self._variable.expression.set_offset(self._src, caller_context.slither_parser.compilation_unit)
+


### PR DESCRIPTION
### Notes

Slither code is written under the assumption that all expressions have offsets which have been initialized using `SourceMapping`'s `set_offset` method. When I added default initializer expressions, I failed to give them an offset. Because of this, default exceptions are raised when we try to display default initializer expressions.

For this PR, I have modified `variable_declaration.py` to set offsets for default initializers. Since default initializers don't actually occur in source code, it uses the offset of the declaration of the variable being initialized. 

This PR is needed for dataflow event history tracking to work. When we display a dataflow path, we display an event for each IR operation, and this event contains the expression corresponding to the ir operation (obtained via `ir.expression`). Some IR operations involving temporary variables may point to default initializer expressions. 

### Testing
* I will soon submit a companion PR in `slither-task` with testing instructions

### Related Issue
https://github.com/CertiKProject/slither-task/issues/343