### PR TITLE
fix: generate default-value array expressions using is_inline_array flag s…

### DIFF
--- a/slither/solc_parsing/default_values.py
+++ b/slither/solc_parsing/default_values.py
@@ -36,7 +36,10 @@ def get_default_value(ty : Type) -> Expression:
         )
     elif isinstance(ty, ArrayType) and ty.is_fixed_array:
         length = int(ty.length_value.value)
-        return TupleExpression([get_default_value(ty.type) for _ in range(0, length)])
+        return TupleExpression(
+            [get_default_value(ty.type) for _ in range(0, length)],
+            is_inline_array = True
+        )
     elif isinstance(ty, UserDefinedType) and isinstance(ty.type, Enum):
         return MemberAccess(
             "min",


### PR DESCRIPTION
### Notes

Previously, running slither on the following program caused an assertion failure 
```
contract DefaultValueCrashTest {
    struct S {
        uint f;
        uint8[2] g;
    }

    function debug() internal {
        S memory v;
    }
}
```
This was because the default value generation code produced tuples instead of arrays, causing a list to appear where an rvalue was expected. This PR fixes the default value generation code, so that it correctly produces array expressions (`TupleExpressions` with the `is_inline_array` flag set to true) to initialize array fields.

### Testing
See [this companion PR](https://github.com/CertiKProject/slither-task/pull/382) for testing instructions.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/381