### PR TITLE
fix: fixed a bug in expression parser where integer literals are parsed as strings

### DIFF
--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -422,7 +422,7 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
                 type_candidate = ElementaryType("uint256")
             else:
                 type_candidate = ElementaryType("string")
-        elif type_candidate.startswith("int_const "):
+        elif type_candidate.startswith("int_const"):
             type_candidate = ElementaryType("uint256")
         elif type_candidate.startswith("bool"):
             type_candidate = ElementaryType("bool")


### PR DESCRIPTION
After `Literal.__str__` improved, I observed a crash from  the "blockchaindigitalcapital" project (hash `4f0a18c8ca8011ca0323bd934f04eb44eeb53436`).

It turned out that slither may parse integer literals as strings. My `Literal.__str__` change made it visible. Before that, string literals could be silently converted to `int` values. This only happens with Solidity versions prior to 0.5, which do not have explicit type description for literals in AST.

Reproducer:
```solidity
pragma solidity ^0.4.24;

contract Test {
    uint[2] data = [
        5, 6
    ];
}
```
