### PR TITLE
fix: have TemporaryVariable store its value's storage location

### DIFF
--- a/slither/slithir/variables/temporary.py
+++ b/slither/slithir/variables/temporary.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from slither.core.children.child_node import ChildNode
 from slither.core.variables.variable import Variable
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 class TemporaryVariable(ChildNode, Variable):
-    def __init__(self, node: "Node", index=None):
+    def __init__(self, node: "Node", index=None, location: Optional[str] = None):
         super().__init__()
         if index is None:
             self._index = node.compilation_unit.counter_slithir_temporary
@@ -16,6 +16,11 @@ class TemporaryVariable(ChildNode, Variable):
         else:
             self._index = index
         self._node = node
+        self._location = location
+
+    @property
+    def location(self):
+        return self._location
 
     @property
     def index(self):

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -296,7 +296,11 @@ class ExpressionToSlithIR(ExpressionVisitor):
             if expression.type_call.startswith("tuple(") and expression.type_call != "tuple()":
                 val = TupleVariable(self._node)
             else:
-                val = TemporaryVariable(self._node)
+                assert len(called.returns) <= 1
+                val = TemporaryVariable(
+                    self._node,
+                    location = called.returns[0].location if len(called.returns) == 1 else None
+                )
             internal_call = InternalCall(called, len(args), val, expression.type_call)
             internal_call.set_expression(expression)
             self._result.append(internal_call)


### PR DESCRIPTION
### Notes

[This issue] describes the problem posed by temporary variables not tracking storage locations. This PR adds a new constructor argument and property to `TemporaryVariable` to store the storage location. It modifies `InternalCall` slithir generation to store the correct location in its lhs variable.

### Testing
* Test using this [companion PR](https://github.com/CertiKProject/slither-task/pull/405) in `slither-task`
* Run `make test`
* Run `./evaluate.sh run 100` in `tool-eval`
 
### Related Issue
https://github.com/CertiKProject/slither-task/issues/408