### PR TITLE
feat: add push operation, include push operation in generated code

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -36,6 +36,7 @@ from slither.core.solidity_types.elementary_type import (
 from slither.core.solidity_types.type import Type
 from slither.core.solidity_types.type_alias import TypeAliasTopLevel, TypeAlias
 from slither.core.variables.function_type_variable import FunctionTypeVariable
+from slither.core.variables.local_variable import LocalVariable
 from slither.core.variables.state_variable import StateVariable
 from slither.core.variables.variable import Variable
 from slither.slithir.exceptions import SlithIRError
@@ -71,6 +72,7 @@ from slither.slithir.operations import (
     Nop,
     Operation,
 )
+from slither.slithir.operations.push import Push
 from slither.slithir.operations.codesize import CodeSize
 from slither.slithir.tmp_operations.argument import Argument, ArgumentType
 from slither.slithir.tmp_operations.tmp_call import TmpCall
@@ -1334,12 +1336,19 @@ def convert_to_push_set_val(
         ir_assign_value.set_node(ir.node)
         ret.append(ir_assign_value)
     else:
-        new_element = ir.lvalue
-        new_element.set_type(new_type)
-        ir_assign_value = Assignment(new_element, element_to_add, new_type)
-        ir_assign_value.set_expression(ir.expression)
-        ir_assign_value.set_node(ir.node)
-        ret.append(ir_assign_value)
+        if node.function.compilation_unit.generates_certik_ir:
+            ir.lvalue.set_type(new_type)
+            ir_allocate_elem = Push(ir.lvalue, arr)
+            ir_allocate_elem.set_expression(ir.expression)
+            ir_allocate_elem.set_node(ir.node)
+            ret.append(ir_allocate_elem)
+        else:
+            new_element = ir.lvalue
+            new_element.set_type(new_type)
+            ir_assign_value = Assignment(new_element, element_to_add, new_type)
+            ir_assign_value.set_expression(ir.expression)
+            ir_assign_value.set_node(ir.node)
+            ret.append(ir_assign_value)
 
 
 def convert_to_push(

--- a/slither/slithir/operations/__init__.py
+++ b/slither/slithir/operations/__init__.py
@@ -29,3 +29,4 @@ from .length import Length
 from .phi import Phi
 from .phi_callback import PhiCallback
 from .nop import Nop
+from .push import Push

--- a/slither/slithir/operations/push.py
+++ b/slither/slithir/operations/push.py
@@ -1,12 +1,10 @@
-
-from typing import List
+from typing import List, Optional
 from slither.core.solidity_types.array_type import ArrayType
 from slither.core.solidity_types.type import Type
 from slither.core.variables.local_variable import LocalVariable
 from slither.core.variables.state_variable import StateVariable
 from slither.core.variables.variable import Variable
 from slither.slithir.operations.lvalue import OperationWithLValue
-from slither.slithir.operations.operation import Operation
 from slither.slithir.utils.utils import is_valid_lvalue
 from slither.slithir.variables import (ReferenceVariable, TemporaryVariable)
 
@@ -23,25 +21,27 @@ def _is_storage_variable(var : Variable) -> bool:
     )
 
 class Push(OperationWithLValue):
-    def __init__(self, lvalue: Variable, array: Variable):
+    def __init__(self, lvalue: Variable, array: Variable, elem: Optional[Variable]):
         """
-        Allocate a new default value.
-
+        Allocate a value and push to dynamic array.
         #### Parameters
         lvalue -
             the lvalue to reference the newly initialized element
         array -
-            The array to push an element to
+            The array to push the element to
+        elem -
+            If present, the element to push to the array. Otherwise, allocate new element with default value.
         """
         assert is_valid_lvalue(lvalue)
         assert isinstance(array, Variable) and isinstance(array.type, ArrayType)
         super().__init__()
         self._array = array
         self._lvalue = lvalue
+        self._elem = elem
 
     @property
     def read(self) -> List[Variable]:
-        return []
+        return [self._elem] if self._elem != None else []
 
     @property
     def array(self) -> Variable:
@@ -53,9 +53,17 @@ class Push(OperationWithLValue):
         return _is_storage_variable(self._array)
 
     @property
+    def elem(self) -> Variable:
+        return self._elem
+
+    @property
     def type(self):
         """Type of element to push"""
         return self._array.type.type
 
     def __str__(self):
-        return f"{self.lvalue} = push {self._array}"
+        if self._elem != None:
+            return f"{self.lvalue} = push {self._elem} to {self._array}"
+        else:
+            return f"{self.lvalue} = push to {self._array}"
+

--- a/slither/slithir/operations/push.py
+++ b/slither/slithir/operations/push.py
@@ -1,0 +1,61 @@
+
+from typing import List
+from slither.core.solidity_types.array_type import ArrayType
+from slither.core.solidity_types.type import Type
+from slither.core.variables.local_variable import LocalVariable
+from slither.core.variables.state_variable import StateVariable
+from slither.core.variables.variable import Variable
+from slither.slithir.operations.lvalue import OperationWithLValue
+from slither.slithir.operations.operation import Operation
+from slither.slithir.utils.utils import is_valid_lvalue
+from slither.slithir.variables import (ReferenceVariable, TemporaryVariable)
+
+def _is_storage_variable(var : Variable) -> bool:
+    return (
+        (isinstance(var, ReferenceVariable) and isinstance(var.points_to_origin, StateVariable))
+        or (
+            isinstance(var, ReferenceVariable)
+            and isinstance(var.points_to_origin, (LocalVariable, TemporaryVariable))
+            and var.points_to_origin.location == "storage"
+        )
+        or (isinstance(var, StateVariable))
+        or (isinstance(var, LocalVariable) and var.location == "storage")
+    )
+
+class Push(OperationWithLValue):
+    def __init__(self, lvalue: Variable, array: Variable):
+        """
+        Allocate a new default value.
+
+        #### Parameters
+        lvalue -
+            the lvalue to reference the newly initialized element
+        array -
+            The array to push an element to
+        """
+        assert is_valid_lvalue(lvalue)
+        assert isinstance(array, Variable) and isinstance(array.type, ArrayType)
+        super().__init__()
+        self._array = array
+        self._lvalue = lvalue
+
+    @property
+    def read(self) -> List[Variable]:
+        return []
+
+    @property
+    def array(self) -> Variable:
+        return self._array
+
+    @property
+    def storage(self) -> bool:
+        """Should we allocate to storage instead of memory?"""
+        return _is_storage_variable(self._array)
+
+    @property
+    def type(self):
+        """Type of element to push"""
+        return self._array.type.type
+
+    def __str__(self):
+        return f"{self.lvalue} = push {self._array}"

--- a/slither/slithir/utils/ssa.py
+++ b/slither/slithir/utils/ssa.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Callable, Dict, List, Tuple, Union
+from slither.slithir.operations.push import Push
 
 import slither.slithir.variables.tuple_ssa
 from slither.core.cfg.node import Node, NodeType
@@ -859,6 +860,10 @@ def copy_ir(ir: Operation, *instances) -> Operation:
         lvalue = get_variable(ir, lambda x: x.lvalue, *instances)
         value = get_variable(ir, lambda x: x.value, *instances)
         return Length(value, lvalue)
+    if isinstance(ir, Push):
+        lvalue = get_variable(ir, lambda x: x.lvalue, *instances)
+        array = get_variable(ir, lambda x: x.array, *instances)
+        return Push(lvalue, array)
 
     raise SlithIRError(f"Impossible ir copy on {ir} ({type(ir)})")
 

--- a/slither/slithir/utils/ssa.py
+++ b/slither/slithir/utils/ssa.py
@@ -863,7 +863,8 @@ def copy_ir(ir: Operation, *instances) -> Operation:
     if isinstance(ir, Push):
         lvalue = get_variable(ir, lambda x: x.lvalue, *instances)
         array = get_variable(ir, lambda x: x.array, *instances)
-        return Push(lvalue, array)
+        elem = get_variable(ir, lambda x:x.elem, *instances)
+        return Push(lvalue, array, elem)
 
     raise SlithIRError(f"Impossible ir copy on {ir} ({type(ir)})")
 


### PR DESCRIPTION
### Notes

The IR for performing a `push` method for dynamic arrays currently uses an `Assign` operation to add the new element to the array. When the left-hand side of an `Assign` is a storage location, a deep copy is performed. Instead of deep copying, we want to allocate a new element in storage. No IR operation currently does this, so this PR adds a new operation called `Push`. 

In addition to allocating a value and adding it to the array, the `Push` operation has an lvalue which is used as the return value for the `push` method. This allows us to access the newly allocated element as an individual instead of using an `Item` abstract value, which conflates the newly allocated element with all the other elements of the array.

### Testing
* A companion PR in `slither-task` will extend DataflowStateMachine to handle Push operations. Testing should be done there.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/461