### PR TITLE
set lvalue to array type instead of element type when propagating typ…

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -790,7 +790,7 @@ def propagate_types(ir: Operation, node: "Node"):  # pylint: disable=too-many-lo
                                 if v:
                                     ir.lvalue.set_type(v.type)
             elif isinstance(ir, NewArray):
-                ir.lvalue.set_type(ir.array_type)
+                ir.lvalue.set_type(ArrayType(ir.array_type, None))
             elif isinstance(ir, NewContract):
                 contract = node.file_scope.get_contract_from_name(ir.contract_name)
                 ir.lvalue.set_type(UserDefinedType(contract))


### PR DESCRIPTION
### Notes

Slither's type propagation sets the lvalue in a `NewArray` IR operation to the array's element type instead of the array type. This PR fixes that issue.

Note that cytic is working on an [upstream fix](https://github.com/crytic/slither/pull/1784/files) for this, but we don't want to wait for them to release it. Their fix is more involved and changes `array_type` to actually refer to the type of the array instead of its element type.

### Issue

https://github.com/CertiKProject/slither-task/issues/529

### Testing
* Modify the `__str__` method of `TemporaryVariable` to print the variable's type along with its name. Run `slither test.sol --print slithir`, where `test.sol` contains the following:
```
contract Test {
  function test() external {
    int[] a = new int[](4);
  }
}
```
Note that without this fix, the type `int` is printed. But with the fix, `int[]` is printed.

* Run `./evaluate.sh run 100` in `tool-eval` and verify that projects succeed
* Run `make test` and verify that tests succeed. 