### PR TITLE
fix: ensure that tuple variable's types belong to the Type class

### DIFF
--- a/slither/core/variables/variable.py
+++ b/slither/core/variables/variable.py
@@ -124,13 +124,6 @@ class Variable(SourceMapping):
             self._type = ElementaryType(t)
             return
         assert isinstance(t, (Type, list)) or t is None
-        if isinstance(t, list):
-            t = [
-                ElementaryType(x)
-                if isinstance(x, str)
-                else x
-                for x in t
-            ]
         self._type = t
 
     @property

--- a/slither/core/variables/variable.py
+++ b/slither/core/variables/variable.py
@@ -124,6 +124,13 @@ class Variable(SourceMapping):
             self._type = ElementaryType(t)
             return
         assert isinstance(t, (Type, list)) or t is None
+        if isinstance(t, list):
+            t = [
+                ElementaryType(x)
+                if isinstance(x, str)
+                else x
+                for x in t
+            ]
         self._type = t
 
     @property

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1620,9 +1620,12 @@ def _convert_to_structure_to_list(return_type: Type) -> List[Type]:
     #         (uint a, uint b) = a.st(0);
     #     }
     # }
-    if isinstance(return_type, (MappingType, ArrayType)):
+    elif isinstance(return_type, (MappingType, ArrayType)):
         return []
-    return [return_type]
+    elif isinstance(return_type, ElementaryType):
+        return [return_type]
+    else:
+        assert False
 
 
 def convert_type_of_high_and_internal_level_call(

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1622,7 +1622,7 @@ def _convert_to_structure_to_list(return_type: Type) -> List[Type]:
     # }
     if isinstance(return_type, (MappingType, ArrayType)):
         return []
-    return [return_type.type]
+    return [return_type]
 
 
 def convert_type_of_high_and_internal_level_call(

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1622,7 +1622,7 @@ def _convert_to_structure_to_list(return_type: Type) -> List[Type]:
     # }
     elif isinstance(return_type, (MappingType, ArrayType)):
         return []
-    elif isinstance(return_type, ElementaryType):
+    elif isinstance(return_type, (ElementaryType, UserDefinedType, TypeAlias)):
         return [return_type]
     else:
         assert False


### PR DESCRIPTION
### Notes

The "types" of the tuple variable generated from a struct-destructuring assignment are actually strings. For example, the tuple variable generated from the following program has a list of strings instead of a list of types:
```
pragma solidity ^0.8.19;

contract OtherContract {
    struct S {
        uint x;
        uint y;
    }

    mapping(uint => S) public m;
}

contract Test {
    OtherContract c;
    function test() external {
        (uint x, uint y) = c.m(0);
    }
}
```

Struct destructuring is implemented in a function called `_convert_to_structure_to_list` in `convert.py`. When it encounters structure types, it destructures them and flattens the result into the outer structure's list. When it encounters elementary types, it *should* include the type in the list, but instead it includes the type's `type` field, which is a string. This PR fixes that by returning the `ElementaryType` instead of its `type` field. 

### Testing
* Run `make test` and verify that all tests succeed
* Run `./evaluate.sh run 100` in `tool-eval.sh` and verify that all projects succeed

### Related Issue
https://github.com/CertiKProject/slither-task/issues/508