### PR TITLE
fix: convert decode arguments to types

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1243,7 +1243,12 @@ def convert_to_solidity_func(
         and len(new_ir.arguments) == 2
         and isinstance(new_ir.arguments[1], list)
     ):
-        types = list(new_ir.arguments[1])
+        def arg_to_type(arg):
+            if isinstance(arg, (Structure, Enum, Contract)):
+                return UserDefinedType(arg)
+            else:
+                return arg
+        types = list(map(arg_to_type, new_ir.arguments[1]))
         new_ir.lvalue.set_type(types)
     # abi.decode where the type to decode is a singleton
     # abi.decode(a, (uint))


### PR DESCRIPTION
### Notes

When the `abi.decode` function decodes a struct along with one or more other values, the type of the tuple on the left-hand side contains an instance of `Structure`, but I expect the tuple variables's `type` field to contain only instances of `Types`.

Instead of containing a `Structure` instance, the list should contain a `UserDefinedType` instance whose `type` field is a `Structure` instance.

This happens because the code handling `decode` does not convert its first argument to a list of types. This PR fixes that by wrapping all `Structure`s, `Enum`s, and `Contracts`s encountered in `UserDefinedType`.

### Testing
* Run `./evaluate.sh run 100` in `tool-eval` and verify that all projects succeed
* Run `make test` and verify that all tests succeed

### Related Issue
https://github.com/CertiKProject/slither-task/issues/511