### PR TITLE
fix: set the reference to the popped element to the correct type

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1408,7 +1408,15 @@ def convert_to_pop(ir, node):
     element_to_delete = ReferenceVariable(node)
     ir_assign_element_to_delete = Index(element_to_delete, arr, val, ElementaryType("uint256"))
     ir_length.lvalue.points_to = arr
-    element_to_delete.set_type(ElementaryType("uint256"))
+    # Note bytes is an ElementaryType not ArrayType so in that case we use ElementaryType("bytes1")
+    # while in other cases such as uint256[] (ArrayType) we use ir.destination.type.type
+    # in this way we will have the type always set to the corresponding ElementaryType
+    assert isinstance(ir.destination.type, (ElementaryType, ArrayType))
+    element_to_delete.set_type(
+        ElementaryType("bytes1")
+        if isinstance(ir.destination.type, ElementaryType)
+        else ir.destination.type.type
+    )
     ir_assign_element_to_delete.set_expression(ir.expression)
     ir_assign_element_to_delete.set_node(ir.node)
     ret.append(ir_assign_element_to_delete)


### PR DESCRIPTION
### Notes

The IR generated for calls to pop (for dynamic array types and `bytes`) would obtain a reference to the last element of the array and then delete it. But the type of this reference was always `uint256` even though it should have been the type of the array element.

Now, we set the reference's type to the array element type. For `bytes`, we set the reference's type to `bytes1`. 

Trail o' Bits [developed a fix](https://github.com/crytic/slither/pull/1905) for this, but I think they used the wrong element type for `bytes`. It should be `bytes1` but they use `bytes`. I will file an issue with them about this.

### Testing
* Run `make test` and verify all tests succeed.
* Run `./evaluate.sh run 100` in `tool-eval` and verify all projects succeed
* Run `pipenv run slither test.sol --print slithir`, where `test.sol` contains the following:

```
pragma solidity ^0.8.13;

contract Poptest {
    struct S {
        int x;
        int y;
    }
    S[] a;
    function poptest() internal {
        a.pop();
    }
}

```

Examine the IR and verify that the deleted reference variable has the correct type. Also, try changing the array `a`'s type to `bytes`.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/501)

### Additional Comments
I commented in the issue I already filed in the Slither repo about handling `bytes` incorrectly.