### PR TITLE
remove code that assigns a variable to the projection index it was or…

### DIFF
--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -191,12 +191,6 @@ class ExpressionToSlithIR(ExpressionVisitor):
                 for idx, _ in enumerate(left):
                     if not left[idx] is None:
                         index = idx
-                        # The following test is probably always true?
-                        if (
-                            isinstance(left[idx], LocalVariableInitFromTuple)
-                            and left[idx].tuple_index is not None
-                        ):
-                            index = left[idx].tuple_index
                         operation = Unpack(left[idx], right, index)
                         operation.set_expression(expression)
                         self._result.append(operation)


### PR DESCRIPTION
### Notes

When a variable is declared in a tuple-destructuring assignment, and then used again on the left hand side of a different tuple-destructuring assignment, the `Unpack` operation generated to project the tuple component into the variable uses the tuple index from the declaration, even on subsequent assignments where it occurs at a different index.

```
(int a, int b, int c) = threeRet();
(, c) = twoRet();
```

```
                Expression: (a,b,c) = threeRet()
                IRs:
                        TUPLE_0(int256,int256,int256) = INTERNAL_CALL, Test.threeRet()()
                        a(int256)= UNPACK TUPLE_0 index: 0 
                        b(int256)= UNPACK TUPLE_0 index: 1 
                        c(int256)= UNPACK TUPLE_0 index: 2 
                Expression: (None,c) = twoRet()
                IRs:
                        TUPLE_1(int256,int256) = INTERNAL_CALL, Test.twoRet()()
                        c(int256)= UNPACK TUPLE_1 index: 2 
```

The code that causes this is in `expression_to_slithir.py` in the `post_assignment_operation` function:
```
                        if (
                             isinstance(left[idx], LocalVariableInitFromTuple)
                             and left[idx].tuple_index is not None
                        ):
                             index = left[idx].tuple_index
```
The variable `index` stores the index used for the projection. This PR removes this code, so that `index` takes on the index that the assigned variable occurs at on the left-hand side. 

I don't think that `LocalVariableInitFromTuple` class is necessary at all at this point.

### Testing
* Run `make test` and verify that all tests succeed
* Run `./evaluate.sh run 100` in `tool-eval` and verify that all projects succeed.
* Run `pipenv run slither test.sol --print slithir` on the following code and verify that the UNPACK indices are correct.

```
contract Test {
    function threeRet() internal returns(int, int, int) {
        return (1,2,3);
    }
    function twoRet() internal returns(int, int) {
        return (3,4);
    }

    function test() external returns(int) {
        (int a, int b, int c) = threeRet();
        (, c) = twoRet();
        return b;
    }
}
```

### Related Issue
https://github.com/CertiKProject/slither-task/issues/505