### PR TITLE
fix: use integer division in constant folding instead of float/rational division

### DIFF
--- a/slither/visitors/expression/constants_folding.py
+++ b/slither/visitors/expression/constants_folding.py
@@ -76,7 +76,7 @@ class ConstantFolding(ExpressionVisitor):
         elif expression.type == BinaryOperationType.MULTIPLICATION:
             set_val(expression, left * right)
         elif expression.type == BinaryOperationType.DIVISION:
-            set_val(expression, left / right)
+            set_val(expression, left // right)
         elif expression.type == BinaryOperationType.MODULO:
             set_val(expression, left % right)
         elif expression.type == BinaryOperationType.ADDITION:


### PR DESCRIPTION
### Notes

Previously, when folding arithmetic on constants, e.g.:
```
contract Test {
    uint constant a = 1;
    uint constant b = 2;

    function test() external returns(uint) {
        uint z = a / b;
        return z + 3;
    }
}
```
The expression `a/b` would be incorrectly folded to `0.5` even though `/` is an integer division operation. Furthermore,  the expression `b/a` would get folded to `2.0` and its type would be recorded as `string` since the `.0` prevents it from parsing as an integer.

This PR modifies the constant folding code to use integer arithmetic instead of floating point arithmetic.

### Testing
* Run `make test` and verify that all tests succeed
* Run `./evaluate.sh run 100` in `tool-eval` and verify that all projects succeed
* Run `pipenv run slither test.sol --print certikir` on the above `Test` contract and verify that the IR assigns `z` to `0`.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/519