### PR TITLE
fix: Preserve padding in tuple-based declarations

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -929,19 +929,24 @@ class FunctionSolc(CallerContextExpression):
                             new_node = self._parse_variable_definition_init_tuple(
                                 new_statement, i, new_node
                             )
+                        else:
+                            variables.append(None)
                         i = i + 1
 
                     var_identifiers = []
                     # craft of the expression doing the assignement
                     for v in variables:
-                        identifier = {
-                            "nodeType": "Identifier",
-                            "referencedDeclaration": v["id"],
-                            "src": v["src"],
-                            "name": v["name"],
-                            "typeDescriptions": {"typeString": v["typeDescriptions"]["typeString"]},
-                        }
-                        var_identifiers.append(identifier)
+                        if v != None:
+                            identifier = {
+                                "nodeType": "Identifier",
+                                "referencedDeclaration": v["id"],
+                                "src": v["src"],
+                                "name": v["name"],
+                                "typeDescriptions": {"typeString": v["typeDescriptions"]["typeString"]},
+                            }
+                            var_identifiers.append(identifier)
+                        else:
+                            var_identifiers.append(None)
 
                     tuple_expression = {
                         "nodeType": "TupleExpression",


### PR DESCRIPTION
### Notes

Previously, in a declaration of the form `(,uint a, uint b) = ...` the leading "padded" position was removed from the AST during a pre-processing step that converted declarations into assignments. The caused the variables `a` and `b` to get assigned to components `0` and `1` instead of `1` and `2`.

This PR preserves the padding during the AST transformation.

### Testing
* Run `make test` and verify that tests succeed
* Run `./evaluate.sh run 100` in `tool-eval` and verify that projects succeed.

Try viewing the IR for this test file:
```
pragma solidity ^0.8.13;

contract Other {
    struct S {
        uint z;
        //uint[] a;
        uint b;        uint c;
        uint d;
    }

    mapping(uint => S) public M;
}

contract Test {
    Other other;

    function test() external {
        (uint z, , uint c, uint d) = other.M(3);
        (z , c, , d) = other.M(3);
    }
}
```

### Related Issue
https://github.com/CertiKProject/slither-task/issues/539
See also: https://github.com/crytic/slither/issues/1913



 