### PR TITLE
fix: only set type of reference to field if field name is in struct type

### DIFF
--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -535,7 +535,12 @@ class ExpressionToSlithIR(ExpressionVisitor):
                 return
 
         val = ReferenceVariable(self._node)
-        if isinstance(expr, Variable) and isinstance(expr.type, UserDefinedType) and isinstance(expr.type.type, Structure):
+        if (
+            isinstance(expr, Variable)
+            and isinstance(expr.type, UserDefinedType)
+            and isinstance(expr.type.type, Structure)
+            and expression.member_name in expr.type.type.elems
+        ):
             val.set_type(expr.type.type.elems[expression.member_name].type)
         member = Member(expr, Constant(expression.member_name), val)
         member.set_expression(expression)


### PR DESCRIPTION
### Notes

In a [recent PR](https://github.com/CertiKProject/slither-certik/pull/50), I added some additional type propagation to IR generation to be able to distinguish the built-in `address.balance` from other fields that happen to be called `balance`. However, it assumes that in any expression of the form `struct.field` the expression `struct` has a struct type with a field named `field`. That is not true due to the using/for construct. This PR modifies the new type propagation code to check that a struct type contains the field before trying to access its type.  

### Testing
* Run `make test` and verify that all tests pass
* Run `./evaluate.sh run 100` in `tool-eval` and verify that all projects succeed.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/566