### PR TITLE
fix: preserve None sub-expressions (for tuple components) during ternary lifting

### DIFF
--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -140,7 +140,7 @@ class SplitTernaryExpression:
         for next_expr in expression.expressions:
             # TODO: can we get rid of `NoneType` expressions in `TupleExpression`?
             # montyly: this might happen with unnamed tuple (ex: (,,,) = f()), but it needs to be checked
-            if next_expr:
+            if next_expr is not None:
 
                 if self.conditional_not_ahead(
                     next_expr, true_expression, false_expression, f_expressions
@@ -151,6 +151,9 @@ class SplitTernaryExpression:
                         true_expression.expressions[-1],
                         false_expression.expressions[-1],
                     )
+            else:
+                true_expression.expressions.append(None)
+                false_expression.expressions.append(None)
 
     def convert_index_access(
         self, next_expr: IndexAccess, true_expression: Expression, false_expression: Expression


### PR DESCRIPTION
### Notes

Previously, when running slither on the following source program:
```
contract Test {

    function getVal(uint z) internal returns(uint, uint) {
        return (0, 1);
    }

    function test(bool flag) external {
        uint a;
        (a, ) = getVal(flag ? 3 : 1);
    }
}
```

Slither would produce this IR:
```
INFO:Printers:Contract Test
        Function Test.getVal(uint256) (*)
                Expression: (0,1)
                IRs:
                        RETURN 0,1
        Function Test.test(bool) (*)
                Expression: flag
                IRs:
                        CONDITION flag
                Expression: (a) = getVal(3)
                IRs:
                        TUPLE_0(uint256,uint256) = INTERNAL_CALL, Test.getVal(uint256)(3)
                        a(uint256) := TUPLE_0([<slither.core.solidity_types.elementary_type.ElementaryType object at 0x101f3d6d0>, <slither.core.solidity_types.elementary_type.ElementaryType object at 0x101f3dfd0>])
                Expression: (a) = getVal(1)
                IRs:
                        TUPLE_1(uint256,uint256) = INTERNAL_CALL, Test.getVal(uint256)(1)
                        a(uint256) := TUPLE_1([<slither.core.solidity_types.elementary_type.ElementaryType object at 0x101f3d6d0>, <slither.core.solidity_types.elementary_type.ElementaryType object at 0x101f3dfd0>])
```

Note that in each case, the `uint256` variable is assigned to a tuple variable instead of the projection of its 0th component. The root of this problem is that the expression syntax `(a) = getVal(0)` is wrong, because the second component of the tuple has been removed.

This happened during ternary lifting in `expression_manipulation.py`. The `convert_expressions` would filter out subexpressions equal to `None` instead of including them in the lifted expressions. That is fixed in this PR.

### Testing
* Try running the example program and observe that its IR has been corrected.
* Run `make test` using [slither-task PR 607](https://github.com/CertiKProject/slither-task/pull/607) and verify that the tests succeed
* Run `./evaluate.sh run 100` in `tool-eval` and verify that all projects succeed.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/597