### PR TITLE
fix: use larger operand type as binop result type

### DIFF
--- a/slither/slithir/operations/binary.py
+++ b/slither/slithir/operations/binary.py
@@ -11,6 +11,7 @@ from slither.slithir.utils.utils import is_valid_lvalue, is_valid_rvalue
 from slither.slithir.variables import ReferenceVariable
 from slither.core.source_mapping.source_mapping import SourceMapping
 from slither.core.variables.variable import Variable
+from slither.core.solidity_types.elementary_type import Int, Uint
 
 
 logger = logging.getLogger("BinaryOperationIR")
@@ -122,6 +123,16 @@ class Binary(OperationWithLValue):
         self._lvalue = result
         if BinaryType.return_bool(operation_type):
             result.set_type(ElementaryType("bool"))
+        elif (
+            isinstance(left_variable.type, ElementaryType)
+            and left_variable.type.type in Uint + Int
+            and isinstance(right_variable.type, ElementaryType)
+            and right_variable.type.type in Uint + Int
+        ):
+            if left_variable.type.size > right_variable.type.size:
+                result.set_type(left_variable.type)
+            else:
+                result.set_type(right_variable.type)
         else:
             result.set_type(left_variable.type)
 

--- a/slither/slithir/operations/binary.py
+++ b/slither/slithir/operations/binary.py
@@ -129,7 +129,7 @@ class Binary(OperationWithLValue):
             and isinstance(right_variable.type, ElementaryType)
             and right_variable.type.type in Uint + Int
         ):
-            if left_variable.type.size > right_variable.type.size:
+            if left_variable.type.size >= right_variable.type.size:
                 result.set_type(left_variable.type)
             else:
                 result.set_type(right_variable.type)


### PR DESCRIPTION
### Notes
This fixes [issue 644](https://github.com/CertiKProject/slither-task/issues/644), which is that the type of the left hand operand is used in a binary operation, even though the larger operand type should be used in the case of integer types.

A better approach would be to insert an explicit cast from the smaller type to the larger type, as noted [here](https://github.com/crytic/slither/issues/284). However, the current PR's approach is easier and works, as far as I know.

### Testing
* Get a local copy of the companion PR and follow its testing instructions.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/644