### PR TITLE
fix: types for REF variables that refer to types

### DIFF
--- a/slither/core/solidity_types/typename_type.py
+++ b/slither/core/solidity_types/typename_type.py
@@ -1,0 +1,28 @@
+from typing import Tuple
+from slither.core.solidity_types.type import Type
+
+class Typename(Type):
+    """
+    The type of a typename expression, which appear, for example, in the second argument
+    of abi.decode
+    """
+    def __init__(self, type: Type):
+        self.type = type
+
+    type : Type
+    """The type that the typename refers to"""
+
+
+    @property
+    def storage_size(self) -> Tuple[int, bool]:
+        #todo: Move storage_size into a subclass of Type called PhysicalType
+        assert False
+
+
+    @property
+    def is_dynamic(self) -> bool:
+        #todo: Move storage_size into a subclass of Type called PhysicalType
+        assert False
+
+    def __str__(self) -> str:
+        return f"typename[{self.type}]"

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -87,6 +87,30 @@ from slither.utils.function import get_function_id
 from slither.utils.type import export_nested_types_from_variable
 from slither.visitors.slithir.expression_to_slithir import ExpressionToSlithIR
 
+import slither.core.declarations.contract
+import slither.core.declarations.function
+import slither.core.solidity_types.elementary_type
+import slither.core.solidity_types.function_type
+import slither.core.solidity_types.user_defined_type
+import slither.slithir.operations.assignment
+import slither.slithir.operations.binary
+import slither.slithir.operations.call
+import slither.slithir.operations.high_level_call
+import slither.slithir.operations.index
+import slither.slithir.operations.init_array
+import slither.slithir.operations.internal_call
+import slither.slithir.operations.length
+import slither.slithir.operations.library_call
+import slither.slithir.operations.low_level_call
+import slither.slithir.operations.member
+import slither.slithir.operations.operation
+import slither.slithir.operations.send
+import slither.slithir.operations.solidity_call
+import slither.slithir.operations.transfer
+import slither.slithir.variables.temporary
+from slither.core.expressions.expression import Expression
+from slither.core.solidity_types.typename_type import Typename
+
 if TYPE_CHECKING:
     from slither.core.cfg.node import Node
 
@@ -1288,6 +1312,17 @@ def convert_to_solidity_func(
     :param ir:
     :return:
     """
+
+    def arg_to_type(arg):
+        """Convert the rvalue `arg` found in the second argument of abi.decode to a type"""
+        if isinstance(arg, (Structure, Enum, Contract)):
+            return UserDefinedType(arg)
+        elif isinstance(arg, ReferenceVariable):
+            assert isinstance(arg.type, Typename)
+            return arg.type.type
+        else:
+            return arg
+
     call = SolidityFunction(f"abi.{ir.function_name}()")
     new_ir = SolidityCall(call, ir.nbr_arguments, ir.lvalue, ir.type_call)
     new_ir.arguments = ir.arguments
@@ -1301,23 +1336,12 @@ def convert_to_solidity_func(
         and len(new_ir.arguments) == 2
         and isinstance(new_ir.arguments[1], list)
     ):
-        def arg_to_type(arg):
-            if isinstance(arg, (Structure, Enum, Contract)):
-                return UserDefinedType(arg)
-            else:
-                return arg
         types = list(map(arg_to_type, new_ir.arguments[1]))
         new_ir.lvalue.set_type(types)
     # abi.decode where the type to decode is a singleton
     # abi.decode(a, (uint))
     elif call == SolidityFunction("abi.decode()") and len(new_ir.arguments) == 2:
-        # If the variable is a referenceVariable, we are lost
-        # See https://github.com/crytic/slither/issues/566 for potential solutions
-        if not isinstance(new_ir.arguments[1], ReferenceVariable):
-            decode_type = new_ir.arguments[1]
-            if isinstance(decode_type, (Structure, Enum, Contract)):
-                decode_type = UserDefinedType(decode_type)
-            new_ir.lvalue.set_type(decode_type)
+        new_ir.lvalue.set_type(arg_to_type(new_ir.arguments[1]))
     else:
         new_ir.lvalue.set_type(call.return_type)
     return new_ir

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -70,6 +70,7 @@ from slither.visitors.expression.expression import ExpressionVisitor
 from slither.visitors.expression.constants_folding import ConstantFolding, NotConstant
 from slither.core.solidity_types.user_defined_type import UserDefinedType
 from slither.core.declarations.structure import Structure
+from slither.core.solidity_types.typename_type import Typename
 
 if TYPE_CHECKING:
     from slither.core.cfg.node import Node
@@ -562,6 +563,15 @@ class ExpressionToSlithIR(ExpressionVisitor):
             and expression.member_name in expr.type.type.elems
         ):
             val_ref.set_type(expr.type.type.elems[expression.member_name].type)
+
+        if isinstance(expr, Contract):
+            if expression.member_name in expr.structures_as_dict:
+                type = UserDefinedType(expr.structures_as_dict[expression.member_name])
+                val_ref.set_type(Typename(type))
+            if expression.member_name in expr.enums_as_dict:
+                type = UserDefinedType(expr.enums_as_dict[expression.member_name])
+                val_ref.set_type(Typename(type))
+
         member = Member(expr, Constant(expression.member_name), val_ref)
         member.set_expression(expression)
         self._result.append(member)


### PR DESCRIPTION
### Notes

When the types that `abi.decode` decodes are located in external contracts, they are not correctly recorded in the LHS. This happens because in IR, REF variables are used in their place. For example, the following code 
```
library A  {
    struct S {
        int x;
    }
}

contract Test {
    function test(bytes calldata z) external {
        A.S memory r = abi.decode(z, (A.S));
    }
}
```

compiles to this IR:
```
Contract Test
        Function Test.test(bytes) (*)
                Expression: r = abi.decode(z,(A.S))
                IRs:
                        REF_1(None) -> A.S
                        TMP_0(None) = SOLIDITY_CALL abi.decode()(z,REF_1)
                        r(A.S) := TMP_0(None)
```

We fix this as follows:
1.) We create a `typename` type constructor to classify types. It contains one field that contains the `Type` being classified.
2.) A REF variable assigned to type `A.S` is given the type `typename(A.S)`
3.) When processing calls to `abi.decode`, we obtain "qualified" types such as `A.S` by looking at the contents of its REF variable's typename. 

After making these changes, the above source code generates this IR:
```
Contract Test
        Function Test.test(bytes) (*)
                Expression: r = abi.decode(z,(A.S))
                IRs:
                        REF_1(typename[A.S]) -> A.S
                        TMP_0(A.S) = SOLIDITY_CALL abi.decode()(z,REF_1)
                        r(A.S) := TMP_0(A.S)
                Expression: ()
                IRs:
                        RETURN 
```

### Testing
* Follow the instructions in the companion PR

### Related Issue
https://github.com/CertiKProject/slither-task/issues/569

### Additional Notes
Ideally, we would not generate `REF` variables to refer to types. However, fixing that would seem to require a deeper change and more digging into slither internals.