### PR TITLE
fix: removed equality method from Literal class

### DIFF
--- a/slither/core/expressions/literal.py
+++ b/slither/core/expressions/literal.py
@@ -68,8 +68,3 @@ class Literal(Expression):
 
         # be sure to handle any character
         return str(self._value)
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, Literal):
-            return False
-        return (self.value, self.subdenomination) == (other.value, other.subdenomination)

--- a/slither/core/solidity_types/array_type.py
+++ b/slither/core/solidity_types/array_type.py
@@ -74,7 +74,18 @@ class ArrayType(Type):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ArrayType):
             return False
-        return self._type == other.type and self.length == other.length
+        return (
+            self._type == other.type
+            and (
+                (
+                    isinstance(self.length, Literal)
+                    and isinstance(other.length, Literal)
+                    and self.length.value == other.length.value
+                    and self.length.subdenomination == other.length.subdenomination
+                )
+                or self.length == other.length
+            )
+        )
 
     def __hash__(self) -> int:
         return hash(str(self))


### PR DESCRIPTION
### Notes

Slither's `Literal` class implements an `__eq__` method but not a `__hash__` method, making it unhashable.  The `eq` implementation was introduced in [this PR](https://github.com/crytic/slither/pull/1348) so that two distinct occurrences of `int[n]` are treated as equal types, where `n` is some literal integer; that was a flawed solution, because it doesn't take into account cases where constants and arithmetic expressions occur in the type expression, e.g. `int[CONST_1 + CONST_2]`

Another problem with giving `Literal` a custom equality operator is that all other `Expression` subclasses use the built-in equality implementation, which is reference equality. It is confusing to have different `Expression` subclasses using different notions of equality.

This PR makes `Literal` hashable by moving the literal equality hack from the `Literal` class into the `ArrayType` class. 

### Testing
* Copy this under `utilities/slither` in a local copy of the `slither-task` repo.
* Run `make test` and verify that all tests succeed
* Run `./evaluate.sh run 100` and verify that all projects succeed
* Print the IR for the code from [this issue](https://github.com/crytic/slither/issues/1286) and verify that a LIBRARY_CALL operation is generated.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/674

### Additional Comments
I created an issue about how giving `Literal` an equality method didn't fix the issue it intended to solve:
https://github.com/CertiKProject/slither-task/issues/689
This issue remains unresolved.
