### PR TITLE
fix: Dont fold division-by-zero

### DIFF
--- a/slither/visitors/expression/constants_folding.py
+++ b/slither/visitors/expression/constants_folding.py
@@ -128,6 +128,9 @@ class ConstantFolding(ExpressionVisitor):
             and isinstance(left, (int, Fraction))
             and isinstance(right, (int, Fraction))
         ):
+            if right == 0:
+                # not a constant because it's not even well defined
+                raise NotConstant
             # TODO: maybe check for right + left to be int to use // ?
             set_val(expression, left // right if isinstance(right, int) else left / right)
         elif (


### PR DESCRIPTION
### Notes

```
pragma solidity ^0.8.0;

contract Test {
    function test() external returns(uint) {
        return uint(0) / uint(0);
    }
}
```

### Testing
* Run `make test` and verify that tests succeed
* Run `./evaluate.sh run 100` in `tool-eval` and verify that projects succeed
* Try running `SOLC_VERSION=0.8.13 pipenv run slither test.sol` where `test.sol` is this file:
```
pragma solidity ^0.8.0;

contract Test {
    function test() external returns(uint) {
        return uint(0) / uint(0);
    }
}
```

Note that [Goodentry](https://accelerator.audit.certikpowered.info/project/986446a0-3bd7-11ee-930f-0f5a744c6a39) project still does not succeed using this fix, because there is a different bug in constant folding that causes a crash.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/692