### PR TITLE
fold constants defined in external libraries

### DIFF
--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -71,6 +71,7 @@ from slither.visitors.expression.constants_folding import ConstantFolding, NotCo
 from slither.core.solidity_types.user_defined_type import UserDefinedType
 from slither.core.declarations.structure import Structure
 from slither.core.solidity_types.typename_type import Typename
+from slither.core.solidity_types.elementary_type import ElementaryTypeName
 
 if TYPE_CHECKING:
     from slither.core.cfg.node import Node
@@ -244,6 +245,8 @@ class ExpressionToSlithIR(ExpressionVisitor):
                 set_val(expression, left)
 
     def _attempt_constant_folding(self, expression):
+        if isinstance(expression.type, str) and not expression.type in ElementaryTypeName:
+            return False
         try:
             const_fold = ConstantFolding(expression, expression.type)
         except (NotConstant, AttributeError):
@@ -471,6 +474,9 @@ class ExpressionToSlithIR(ExpressionVisitor):
         set_val(expression, cst)
 
     def _post_member_access(self, expression: MemberAccess) -> None:
+        if self._node.compilation_unit.generates_certik_ir and self._attempt_constant_folding(expression):
+            return
+
         expr = get(expression.expression)
 
         # Look for type(X).max / min


### PR DESCRIPTION
### Notes

Previously, constants defined in external libraries would not appear as constants at their occurrences in IR.

This source:
```
library Lib {
    uint constant SLASH_FACTOR_DECIMAL = 1e6;
}

contract Test {
    function test() external {
        uint a = Lib.SLASH_FACTOR_DECIMAL;
    }
}
```

Would generate this IR:
```
INFO:Printers:Contract Lib
        Function Lib.slitherConstructorConstantVariables() (*)
                Expression: SLASH_FACTOR_DECIMAL = 1e6
                IRs:
                        SLASH_FACTOR_DECIMAL(uint256) := 1000000(uint256)
Contract Test
        Function Test.test() (*)
                Expression: a = Lib.SLASH_FACTOR_DECIMAL
                IRs:
                        REF_0(uint256) -> Lib.SLASH_FACTOR_DECIMAL
                        a(uint256) := REF_0(uint256)
```

This PR extends constant folding to deal with `MemberAccess` expressions, checking if `e` in `e.m` is a library and if it's 
member name `m` refers to a constant definition.

After adding this PR's changes, the generated IR is:
```
 INFO:Printers:Contract Lib
        Function Lib.slitherConstructorConstantVariables() (*)
                Expression: SLASH_FACTOR_DECIMAL = 1e6
                IRs:
                        SLASH_FACTOR_DECIMAL(uint256) := 1000000(uint256)
Contract Test
        Function Test.test() (*)
                Expression: a = Lib.SLASH_FACTOR_DECIMAL
                IRs:
                        a(uint256) := 1000000(int256)
                Expression: ()
                IRs:
                        RETURN 
```

This prevents many FPs in integer analysis.

### Testing
* Run `make test` and verify that tests succeed
* Run `./evaluate.sh run 100` in `tool-eval` and verify that all projects succeed

### Related Issue
https://github.com/CertiKProject/slither-task/issues/554