### PR TITLE
feat: enable incorrect-using-for and cache-array-length detectors

### DIFF
--- a/slither/detectors/operations/cache_array_length.py
+++ b/slither/detectors/operations/cache_array_length.py
@@ -14,7 +14,7 @@ class CacheArrayLength(AbstractDetector):
     Detects `for` loops that use `length` member of some storage array in their loop condition and don't modify it.
     """
 
-    ARGUMENT = "cache-array-length"
+    ARGUMENT = "slither-cache-array-length"
     HELP = (
         "Detects `for` loops that use `length` member of some storage array in their loop condition and don't "
         "modify it. "
@@ -34,8 +34,8 @@ class CacheArrayLength(AbstractDetector):
 contract C
 {
     uint[] array;
-    
-    function f() public 
+
+    function f() public
     {
         for (uint i = 0; i < array.length; i++)
         {
@@ -50,8 +50,8 @@ Since the `for` loop in `f` doesn't modify `array.length`, it is more gas effici
 contract C
 {
     uint[] array;
-    
-    function f() public 
+
+    function f() public
     {
         uint array_length = array.length;
         for (uint i = 0; i < array_length; i++)
@@ -216,8 +216,7 @@ contract C
         for usage in non_optimal_array_len_usages:
             info = [
                 "Loop condition ",
-                f"`{usage.source_mapping.content}` ",
-                f"({usage.source_mapping}) ",
+                usage,
                 "should use cached array length instead of referencing `length` member "
                 "of the storage array.\n ",
             ]

--- a/slither/detectors/statements/incorrect_using_for.py
+++ b/slither/detectors/statements/incorrect_using_for.py
@@ -18,7 +18,6 @@ from slither.detectors.abstract_detector import (
 )
 from slither.utils.output import Output
 
-
 def _is_correctly_used(type_: Type, library: Contract) -> bool:
     """
     Checks if a `using library for type_` statement is used correctly (that is, does library contain any function
@@ -160,7 +159,7 @@ class IncorrectUsingFor(AbstractDetector):
     Detector for incorrect using-for statement usage.
     """
 
-    ARGUMENT = "incorrect-using-for"
+    ARGUMENT = "slither-incorrect-using-for"
     HELP = "Detects using-for statement usage when no function from a given library matches a given type"
     IMPACT = DetectorClassification.INFORMATIONAL
     CONFIDENCE = DetectorClassification.HIGH
@@ -181,7 +180,7 @@ class IncorrectUsingFor(AbstractDetector):
     library L {
         function f(bool) public pure {}
     }
-    
+
     using L for uint;
     ```
     Such a code will compile despite the fact that `L` has no function with `uint` as its first argument."""
@@ -195,11 +194,12 @@ class IncorrectUsingFor(AbstractDetector):
         self, results: List[Output], uf: UsingForTopLevel, type_: Type, library: Contract
     ) -> None:
         info: DETECTOR_INFO = [
-            f"using-for statement at {uf.source_mapping} is incorrect - no matching function for {type_} found in ",
-            library,
-            ".\n",
+            f"statement {uf} is incorrect - no matching function for {type_} found in '{library.name}.\n",
         ]
+
         res = self.generate_result(info)
+        res.add(uf, { "lib" : str(library.name), "ty": str(type_) })
+
         results.append(res)
 
     def _detect(self) -> List[Output]:

--- a/slither/utils/output.py
+++ b/slither/utils/output.py
@@ -20,6 +20,7 @@ from slither.core.declarations import (
     FunctionContract,
     CustomError
 )
+from slither.core.declarations.using_for_top_level import UsingForTopLevel
 from slither.core.expressions import Expression
 from slither.core.source_mapping.source_mapping import SourceMapping
 from slither.core.variables.local_variable import LocalVariable
@@ -249,7 +250,7 @@ def _convert_to_description(d: str) -> str:
     if hasattr(d, "name"):
         return f"{d.name} ({d.source_mapping})"
 
-    if isinstance(d, Expression):
+    if isinstance(d, (Expression, UsingForTopLevel)):
         return f"{d}({d.source_mapping})"
 
     raise SlitherError(f"{type(d)} cannot be converted (no name, or canonical_name")
@@ -273,7 +274,7 @@ def _convert_to_markdown(d: str, markdown_root: str) -> str:
     if hasattr(d, "name"):
         return f"[{d.name}]({d.source_mapping.to_markdown(markdown_root)})"
 
-    if isinstance(d, Expression):
+    if isinstance(d, (Expression, UsingForTopLevel)):
         return f"{d}({d.source_mapping.to_markdown(markdown_root)})"
 
     raise SlitherError(f"{type(d)} cannot be converted (no name, or canonical_name")
@@ -305,7 +306,7 @@ def _convert_to_id(d: str) -> str:
     if hasattr(d, "name"):
         return f"{d.name}"
 
-    if isinstance(d, Expression):
+    if isinstance(d, (Expression, UsingForTopLevel)):
         return f"{d}({d.source_mapping})"
 
     raise SlitherError(f"{type(d)} cannot be converted (no name, or canonical_name")
@@ -452,6 +453,8 @@ class Output:
             self.add_struct(add, additional_fields=additional_fields)
         elif isinstance(add, Pragma):
             self.add_pragma(add, additional_fields=additional_fields)
+        elif isinstance(add, UsingForTopLevel):
+            self.add_using_for(add, additional_fields=additional_fields)
         elif isinstance(add, Node):
             self.add_node(add, additional_fields=additional_fields)
         elif isinstance(add, CustomError):
@@ -653,6 +656,22 @@ class Output:
 
     # endregion
     ###################################################################################
+    ###################################################################################
+    # region UsingFor
+    ###################################################################################
+
+    def add_using_for(self, using_for: UsingForTopLevel, additional_fields: Optional[Dict] = None) -> None:
+        if additional_fields is None:
+            additional_fields = {}
+        element = _create_base_element(
+            "using_for",
+            "using for statement",
+            using_for.source_mapping.to_json(),
+            {},
+            additional_fields
+        )
+        self._data["elements"].append(element)
+
     ###################################################################################
     # region File
     ###################################################################################


### PR DESCRIPTION
### Notes

This PR enables the `cache-array-length` and `incorrect-using-for` detectors introduced with Slither 0.9.4 by Trail of Bits. This fixes some issues encountered trying to display the findings of these detectors:

- `cache-array-length` did not include any elements in its output, so there was no source link. This has been fixed by adding the MemberAccess expression as an element.
- `incorrect-using-for` used the library declaration as an element, because `using-for` support hadn't been handled in `output.py`. This was confusing because the finding referred to a location that did not cause the issue. I fixed this by handling `using--for` in `output.py` and adding the `using-for` instead of the library declaration as an element to the finding. 

### Testing
See the companion PR.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/670