### PR TITLE
fix: format name correctly for using-for struct

### DIFF
--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -628,7 +628,8 @@ class ContractSolc(CallerContextExpression):
                         uf = StructureContract(self._contract.compilation_unit)
                         uf.set_offset(using_for["src"], self._contract.compilation_unit)
                         StructureContract.set_contract(uf, self._contract)
-                        using_string = "using {" + ",".join(using_for["functionList"]) + "}"
+                        function_names = [d["function"]["name"] for d in using_for["functionList"]]
+                        using_string = "using {" + ",".join(function_names) + "}"
                         uf.canonical_name = uf.name = f"{using_string} for {type_name} in {self._contract}"
                         # We have a list of functions. A function can be topLevel or a library function
                         self._analyze_function_list(using_for["functionList"], type_name, uf)


### PR DESCRIPTION
### Notes

When analyzing a `using-for` statement which uses a function list, i.e. a statement of the form `using {func1, func2, ...} for type`, we previously weren't traversing the json syntax correctly, leading to a crash. This PR correctly accesses the list of function names.

### Testing
* Follow the testing instructions in the (forthcoming) slither-task companion PR.

### Related Issue
https://github.com/CertiKProject/slither-task/issues/697
